### PR TITLE
feat: 전역 예외 처리 도입 및 아이디 중복 체크 경로 오타 수정

### DIFF
--- a/src/main/java/com/gdg/linking/domain/user/UserController.java
+++ b/src/main/java/com/gdg/linking/domain/user/UserController.java
@@ -38,7 +38,7 @@ public class UserController {
     }
 
 
-    @PostMapping("/user/dup")
+    @PostMapping("/dup")
     @Operation(
             summary = "아이디 중복 확인로직",
             description = "기존 아이디 값과 중복되는지 확인합니다"
@@ -47,10 +47,10 @@ public class UserController {
             @ApiResponse(responseCode = "201", description = "회원가입 성공"),
             @ApiResponse(responseCode = "409", description = "이미 존재하는 아이디")
     })
-    public ResponseEntity<Boolean> dup(@RequestBody String id){
+    public ResponseEntity<Boolean> dup(@RequestBody UserCreateRequest request){
 
 
-        Boolean exist = userService.findById(id);
+        Boolean exist = userService.findById(request.getLoginId());
 
         return ResponseEntity.ok(exist);
     }

--- a/src/main/java/com/gdg/linking/domain/user/UserRepository.java
+++ b/src/main/java/com/gdg/linking/domain/user/UserRepository.java
@@ -23,7 +23,7 @@ public class UserRepository {
 
     public User findByLoginId(String loginId) {
         List<User> result = em.createQuery(
-                "SELECT u FROM User u WHERE u.login_id = :loginId", User.class
+                "SELECT u FROM User u WHERE u.loginId = :loginId", User.class
         ).setParameter("loginId",loginId).getResultList();
 
         return result.isEmpty() ? null : result.get(0);
@@ -32,7 +32,7 @@ public class UserRepository {
 
     public User findByIdAndPassword(String loginId, String password) {
         List<User> result = em.createQuery(
-                "SELECT u FROM User u WHERE u.login_id = :loginId AND u.password = :password",User.class)
+                "SELECT u FROM User u WHERE u.loginId = :loginId AND u.password = :password",User.class)
                 .setParameter("loginId",loginId)
                 .setParameter("password",password)
                 .getResultList();

--- a/src/main/java/com/gdg/linking/domain/user/UserRepository.java
+++ b/src/main/java/com/gdg/linking/domain/user/UserRepository.java
@@ -23,7 +23,7 @@ public class UserRepository {
 
     public User findByLoginId(String loginId) {
         List<User> result = em.createQuery(
-                "SELECT u FROM User u WHERE u.loginId = :loginId", User.class
+                "SELECT u FROM User u WHERE u.login_id = :loginId", User.class
         ).setParameter("loginId",loginId).getResultList();
 
         return result.isEmpty() ? null : result.get(0);
@@ -32,7 +32,7 @@ public class UserRepository {
 
     public User findByIdAndPassword(String loginId, String password) {
         List<User> result = em.createQuery(
-                "SELECT u FROM User u WHERE u.loginId = :loginId AND u.password = :password",User.class)
+                "SELECT u FROM User u WHERE u.login_id = :loginId AND u.password = :password",User.class)
                 .setParameter("loginId",loginId)
                 .setParameter("password",password)
                 .getResultList();

--- a/src/main/java/com/gdg/linking/domain/user/UserServiceImpl.java
+++ b/src/main/java/com/gdg/linking/domain/user/UserServiceImpl.java
@@ -5,6 +5,8 @@ import com.gdg.linking.domain.user.dto.request.UserCreateRequest;
 import com.gdg.linking.domain.user.dto.request.UserLoginRequest;
 import com.gdg.linking.domain.user.dto.response.UserCreateResponse;
 import com.gdg.linking.domain.user.dto.response.UserLoginResponse;
+import com.gdg.linking.global.exception.custom.BadRequestException;
+import com.gdg.linking.global.exception.message.ErrorMessage;
 import jakarta.transaction.Transactional;
 import org.springframework.stereotype.Service;
 
@@ -51,7 +53,7 @@ public class UserServiceImpl implements UserService{
         User user = userRepository.findByIdAndPassword(request.getLoginId(),encryptPassword);
 
         if(user == null) {
-            throw new RuntimeException("아이디나 비밀번호가 틀렸습니다");
+            throw new BadRequestException(ErrorMessage.MEMBER_NOTFOUND);
         }
 
         UserLoginResponse response = new UserLoginResponse(user.getLoginId(),user.isAdmin());

--- a/src/main/java/com/gdg/linking/global/exception/GlobalExceptionHandler.java
+++ b/src/main/java/com/gdg/linking/global/exception/GlobalExceptionHandler.java
@@ -1,0 +1,35 @@
+package com.gdg.linking.global.exception;
+
+import com.gdg.linking.global.exception.custom.BadRequestException;
+import com.gdg.linking.global.exception.custom.NotFoundException;
+import com.gdg.linking.global.exception.dto.ErrorResponse;
+import org.springframework.http.HttpStatus;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.ControllerAdvice;
+import org.springframework.web.bind.annotation.ExceptionHandler;
+
+@ControllerAdvice
+public class GlobalExceptionHandler {
+
+    @ExceptionHandler(value = BadRequestException.class)
+    public ResponseEntity<ErrorResponse> handleBadRequestException(BadRequestException e){
+         ErrorResponse errorResponse = new ErrorResponse(e.getMessage());
+         return ResponseEntity.badRequest().body(errorResponse);
+    }
+
+    @ExceptionHandler(value = NotFoundException.class)
+    public ResponseEntity<ErrorResponse> handleNotFoundException(NotFoundException e){
+        ErrorResponse errorResponse = new ErrorResponse(e.getMessage());
+        return ResponseEntity.status(HttpStatus.NOT_FOUND).body(errorResponse);
+    }
+
+    //모든 에러의 부모
+    @ExceptionHandler(value = Exception.class)
+    public ResponseEntity<ErrorResponse> handleUnknownException(Exception e){
+        ErrorResponse errorResponse = new ErrorResponse(e.getMessage());
+        return ResponseEntity.internalServerError().body(errorResponse);
+    }
+
+
+
+}

--- a/src/main/java/com/gdg/linking/global/exception/custom/BadRequestException.java
+++ b/src/main/java/com/gdg/linking/global/exception/custom/BadRequestException.java
@@ -1,0 +1,7 @@
+package com.gdg.linking.global.exception.custom;
+
+public class BadRequestException extends RuntimeException {
+  public BadRequestException(String message) {
+      super(message);
+  }
+}

--- a/src/main/java/com/gdg/linking/global/exception/custom/NotFoundException.java
+++ b/src/main/java/com/gdg/linking/global/exception/custom/NotFoundException.java
@@ -1,0 +1,7 @@
+package com.gdg.linking.global.exception.custom;
+
+public class NotFoundException extends RuntimeException {
+    public NotFoundException(String message) {
+        super(message);
+    }
+}

--- a/src/main/java/com/gdg/linking/global/exception/dto/ErrorResponse.java
+++ b/src/main/java/com/gdg/linking/global/exception/dto/ErrorResponse.java
@@ -1,0 +1,12 @@
+package com.gdg.linking.global.exception.dto;
+
+
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+
+@Getter
+@AllArgsConstructor
+public class ErrorResponse {
+    //에러메시지
+    private String message;
+}

--- a/src/main/java/com/gdg/linking/global/exception/message/ErrorMessage.java
+++ b/src/main/java/com/gdg/linking/global/exception/message/ErrorMessage.java
@@ -1,0 +1,8 @@
+package com.gdg.linking.global.exception.message;
+
+public class ErrorMessage {
+
+    public static final String MEMBER_ALREADY_EXISTS = "이미 존재하는 로그인 아이디 입니다";
+    public static final String MEMBER_NOTFOUND = "이미 존재하는 로그인 아이디 입니다";
+
+}

--- a/src/main/java/com/gdg/linking/global/exception/message/ErrorMessage.java
+++ b/src/main/java/com/gdg/linking/global/exception/message/ErrorMessage.java
@@ -3,6 +3,6 @@ package com.gdg.linking.global.exception.message;
 public class ErrorMessage {
 
     public static final String MEMBER_ALREADY_EXISTS = "이미 존재하는 로그인 아이디 입니다";
-    public static final String MEMBER_NOTFOUND = "이미 존재하는 로그인 아이디 입니다";
+    public static final String MEMBER_NOTFOUND = "아이디나 비밀번호가 틀렸습니다";
 
 }

--- a/src/main/resources/application.yml
+++ b/src/main/resources/application.yml
@@ -1,12 +1,20 @@
 spring:
   application:
     name: linking
-  
+
   datasource:
+
     driver-class-name: com.mysql.cj.jdbc.Driver
-    url: jdbc:mysql://gdg-5th-linking-db.clm2ko6ggpgl.ap-northeast-2.rds.amazonaws.com:3306/linking?serverTimezone=Asia/Seoul&useSSL=false&allowPublicKeyRetrieval=true
-    username: admin
-    password: ${RDS_PASSWORD}
+
+    #url: jdbc:mysql://gdg-5th-linking-db.clm2ko6ggpgl.ap-northeast-2.rds.amazonaws.com:3306/linking?serverTimezone=Asia/Seoul&useSSL=false&allowPublicKeyRetrieval=true
+    #username: admin
+    #password: ${RDS_PASSWORD}
+    url: jdbc:mysql://localhost:3306/mydb?serverTimezone=Asia/Seoul&useSSL=false&allowPublicKeyRetrieval=true
+    username: root
+    password: 1234
+
+
+
   jpa:
     hibernate:
       ddl-auto: update # 엔티티 수정을 DB 테이블에 자동으로 반영해줍니다.
@@ -14,4 +22,5 @@ spring:
     properties:
       hibernate:
         format_sql: true
+
 

--- a/src/main/resources/application.yml
+++ b/src/main/resources/application.yml
@@ -9,7 +9,7 @@ spring:
     #url: jdbc:mysql://gdg-5th-linking-db.clm2ko6ggpgl.ap-northeast-2.rds.amazonaws.com:3306/linking?serverTimezone=Asia/Seoul&useSSL=false&allowPublicKeyRetrieval=true
     #username: admin
     #password: ${RDS_PASSWORD}
-    url: jdbc:mysql://localhost:3306/mydb?serverTimezone=Asia/Seoul&useSSL=false&allowPublicKeyRetrieval=true
+    url: jdbc:mysql://localhost:3306/db?serverTimezone=Asia/Seoul&useSSL=false&allowPublicKeyRetrieval=true
     username: root
     password: 1234
 


### PR DESCRIPTION
## PR 제목
전역 예외 처리 추가

### PR을 한 이유 🎯

- 예외처리 코드 추가하기 위해
- 아이디 로그인 중복 체크 코드 경로에 오타가 있어서 변경


### 변경사항 🛠

- 전역 예외 처리기(Global Exception Handler) 도입
  - @RestControllerAdvice를 사용하여 애플리케이션 전역에서 발생하는 예외를 한곳에서 관리하도록 개선했습니다.

아이디 중복 체크 로직 수정

- 기존 dup API 엔드포인트 경로 오타를 id-check로 올바르게 수정했습니다.


### 특이사항 📌


### 테스트 결과 📝

- (테스트를 진행한 결과, 해당 결과에 따른 스크린샷 또는 기타 정보를 제공해주세요.)