### PR TITLE
아이템 링크 기능 추가

### DIFF
--- a/src/main/java/com/gdg/linking/domain/item/Item.java
+++ b/src/main/java/com/gdg/linking/domain/item/Item.java
@@ -8,6 +8,8 @@ import org.springframework.data.annotation.CreatedDate;
 import org.springframework.data.jpa.domain.support.AuditingEntityListener;
 
 import java.time.LocalDate;
+import java.util.ArrayList;
+import java.util.List;
 
 @Entity
 @Table(name ="items")
@@ -73,7 +75,27 @@ public class Item {
     @Column(name = "created_at")
     private LocalDate createdAt;
 
+    @ManyToMany
+    @JoinTable(
+            name = "item_relations",           // 생성될 중간 테이블 이름
+            joinColumns = @JoinColumn(name = "from_id"),    // 현재 아이템(출발점) 외래키
+            inverseJoinColumns = @JoinColumn(name = "to_id") // 연결될 아이템(도착점) 외래키
+    )
+    private List<Item> relatedItems = new ArrayList<>();
 
+    // 연결 편의 메서드
+    public void addRelation(Item target) {
+        if (target != null && !this.relatedItems.contains(target)) {
+            this.relatedItems.add(target);
+        }
+    }
+
+    // 연결 해제 메서드
+    public void removeRelation(Item target) {
+        if (target != null) {
+            this.relatedItems.remove(target);
+        }
+    }
 
     //업데이트 전용 메서드
     public void update(String url, String title, String memo, boolean importance, LocalDate deadline) {

--- a/src/main/java/com/gdg/linking/domain/item/Item.java
+++ b/src/main/java/com/gdg/linking/domain/item/Item.java
@@ -8,6 +8,7 @@ import org.springframework.data.annotation.CreatedDate;
 import org.springframework.data.jpa.domain.support.AuditingEntityListener;
 
 import java.time.LocalDate;
+import java.time.LocalDateTime;
 import java.util.ArrayList;
 import java.util.List;
 
@@ -72,8 +73,8 @@ public class Item {
     private LocalDate deletedAt;
 
     @CreatedDate
-    @Column(name = "created_at")
-    private LocalDate createdAt;
+    @Column(name = "created_at", updatable = false) // 생성 시각은 수정되지 않도록 설정 권장
+    private LocalDateTime createdAt;
 
     @ManyToMany
     @JoinTable(

--- a/src/main/java/com/gdg/linking/domain/item/ItemContoller.java
+++ b/src/main/java/com/gdg/linking/domain/item/ItemContoller.java
@@ -9,6 +9,8 @@ import com.gdg.linking.domain.item.dto.response.ItemGetResponse;
 import com.gdg.linking.domain.item.dto.response.ItemUpdateResponse;
 import com.gdg.linking.global.aop.LoginCheck;
 import io.swagger.v3.oas.annotations.Operation;
+import io.swagger.v3.oas.annotations.Parameter;
+import io.swagger.v3.oas.annotations.media.ArraySchema;
 import io.swagger.v3.oas.annotations.media.Content;
 import io.swagger.v3.oas.annotations.media.Schema;
 import io.swagger.v3.oas.annotations.responses.ApiResponse;
@@ -130,5 +132,26 @@ public class ItemContoller {
     }
 
 
+    @LoginCheck
+    @Operation(
+            summary = "폴더별 아이템 목록 조회",
+            description = "특정 폴더(folderId)에 속한 모든 아이템 리스트를 가져옵니다. 로그인한 사용자의 권한 확인이 필요합니다."
+    )
+    @ApiResponses(value = {
+            @ApiResponse(responseCode = "200", description = "조회 성공",
+                    content = @Content(array = @ArraySchema(schema = @Schema(implementation = ItemGetResponse.class)))),
+            @ApiResponse(responseCode = "401", description = "인증 실패 (로그인 필요)"),
+            @ApiResponse(responseCode = "404", description = "존재하지 않는 폴더 ID"),
+            @ApiResponse(responseCode = "500", description = "서버 오류")
+    })
+    @GetMapping("/{folderId}")
+    public ResponseEntity<List<ItemGetResponse>> getFolderItem(@PathVariable Long folderId,
+                                                               @Parameter(hidden = true) HttpSession session){
+
+        Long userId = getLoginUserId(session);
+        List<ItemGetResponse> response = itemService.getByFolderId(folderId);
+
+        return ResponseEntity.ok(response);
+    }
 
 }

--- a/src/main/java/com/gdg/linking/domain/item/ItemContoller.java
+++ b/src/main/java/com/gdg/linking/domain/item/ItemContoller.java
@@ -3,10 +3,9 @@ package com.gdg.linking.domain.item;
 
 import com.gdg.linking.domain.item.dto.request.ItemCreateRequest;
 import com.gdg.linking.domain.item.dto.request.ItemUpdateRequest;
-import com.gdg.linking.domain.item.dto.response.ItemCreateResponse;
-import com.gdg.linking.domain.item.dto.response.ItemDeleteResponse;
-import com.gdg.linking.domain.item.dto.response.ItemGetResponse;
-import com.gdg.linking.domain.item.dto.response.ItemUpdateResponse;
+import com.gdg.linking.domain.item.dto.request.RelatedDeleteRequest;
+import com.gdg.linking.domain.item.dto.request.RelatedItemRequest;
+import com.gdg.linking.domain.item.dto.response.*;
 import com.gdg.linking.global.aop.LoginCheck;
 import io.swagger.v3.oas.annotations.Operation;
 import io.swagger.v3.oas.annotations.Parameter;
@@ -16,12 +15,12 @@ import io.swagger.v3.oas.annotations.media.Schema;
 import io.swagger.v3.oas.annotations.responses.ApiResponse;
 import io.swagger.v3.oas.annotations.responses.ApiResponses;
 import jakarta.servlet.http.HttpSession;
-import lombok.Getter;
-import org.apache.coyote.Response;
+import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.*;
 
 import java.util.List;
+import java.util.Map;
 
 import static com.gdg.linking.global.utils.SessionUtil.getLoginUserId;
 
@@ -144,7 +143,7 @@ public class ItemContoller {
             @ApiResponse(responseCode = "404", description = "존재하지 않는 폴더 ID"),
             @ApiResponse(responseCode = "500", description = "서버 오류")
     })
-    @GetMapping("/{folderId}")
+    @GetMapping("folder/{folderId}")
     public ResponseEntity<List<ItemGetResponse>> getFolderItem(@PathVariable Long folderId,
                                                                @Parameter(hidden = true) HttpSession session){
 
@@ -152,6 +151,46 @@ public class ItemContoller {
         List<ItemGetResponse> response = itemService.getByFolderId(folderId);
 
         return ResponseEntity.ok(response);
+    }
+
+    @LoginCheck
+    @Operation(summary = "연관 링크 목록 조회", description = "특정 아이템에 연결된 모든 연관 링크를 조회합니다.")
+    @GetMapping("/link/{itemId}")
+    public ResponseEntity<List<RelatedItemResponse>> linkItem(@PathVariable Long itemId){
+
+        List<RelatedItemResponse> response = itemService.getAllRelatedLinks(itemId);
+
+        return ResponseEntity.ok(response);
+    }
+    @LoginCheck
+    @Operation(summary = "연관 링크 등록", description = "두 아이템 사이에 연관 관계를 생성합니다.")
+    @PostMapping("/link")
+    public ResponseEntity<List<RelatedItemResponse>> linkItem(@RequestBody RelatedItemRequest request){
+
+        itemService.addRelatedLink(request.getItemId(), request.getLinkItemId());
+
+
+        // 2. 갱신된 전체 리스트 조회 (Service에서 처리 권장)
+        List<RelatedItemResponse> updatedList = itemService.getAllRelatedLinks(request.getItemId());
+
+
+        return ResponseEntity.ok(updatedList);
+    }
+
+    @LoginCheck
+    @Operation(summary = "연관 링크 해제", description = "두 아이템 사이의 연관 관계를 삭제합니다.")
+    @DeleteMapping("/link")
+    public ResponseEntity<List<RelatedItemResponse>> linkItem(@RequestBody RelatedDeleteRequest request,
+                                         HttpSession session){
+
+        Long userId = getLoginUserId(session);
+        itemService.disconnectItems(request.getItemId(),request.getLinkItemId(),userId);
+
+        // 2. 갱신된 전체 리스트 조회 (Service에서 처리 권장)
+        List<RelatedItemResponse> updatedList = itemService.getAllRelatedLinks(request.getItemId());
+
+
+        return ResponseEntity.ok(updatedList);
     }
 
 }

--- a/src/main/java/com/gdg/linking/domain/item/ItemRepository.java
+++ b/src/main/java/com/gdg/linking/domain/item/ItemRepository.java
@@ -15,5 +15,5 @@ public interface ItemRepository extends JpaRepository<Item, Long>{
     @Query("SELECT i FROM Item i JOIN i.relatedItems ri WHERE ri.itemId = :itemId")
     List<Item> findItemsLinkingToMe(@Param("itemId") Long itemId);
 
-    List<ItemGetResponse> findByFolderId(Long folderId);
+    List<Item> findByFolder_fId(Long fId);
 }

--- a/src/main/java/com/gdg/linking/domain/item/ItemRepository.java
+++ b/src/main/java/com/gdg/linking/domain/item/ItemRepository.java
@@ -1,11 +1,19 @@
 package com.gdg.linking.domain.item;
 
+import com.gdg.linking.domain.item.dto.response.ItemGetResponse;
 import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Query;
+import org.springframework.data.repository.query.Param;
 
 import java.util.List;
 
 public interface ItemRepository extends JpaRepository<Item, Long>{
 
     List<Item> findAllByUser_UserIdOrderByCreatedAtDesc(Long userId);
-    
+
+    // 이 부분을 추가해야 합니다!
+    @Query("SELECT i FROM Item i JOIN i.relatedItems ri WHERE ri.itemId = :itemId")
+    List<Item> findItemsLinkingToMe(@Param("itemId") Long itemId);
+
+    List<ItemGetResponse> findByFolderId(Long folderId);
 }

--- a/src/main/java/com/gdg/linking/domain/item/ItemService.java
+++ b/src/main/java/com/gdg/linking/domain/item/ItemService.java
@@ -25,7 +25,13 @@ public interface ItemService {
 
     void disconnectItems(Long fromId, Long toId, Long userId);
 
-    Map<String, List<RelatedItemResponse>> getAllRelatedLinks(Long itemId);
+    List<RelatedItemResponse> getAllRelatedLinks(Long itemId);
+
+
+
+
+
+
 
     List<ItemGetResponse> getByFolderId(Long folderId);
 }

--- a/src/main/java/com/gdg/linking/domain/item/ItemService.java
+++ b/src/main/java/com/gdg/linking/domain/item/ItemService.java
@@ -2,12 +2,10 @@ package com.gdg.linking.domain.item;
 
 import com.gdg.linking.domain.item.dto.request.ItemCreateRequest;
 import com.gdg.linking.domain.item.dto.request.ItemUpdateRequest;
-import com.gdg.linking.domain.item.dto.response.ItemCreateResponse;
-import com.gdg.linking.domain.item.dto.response.ItemDeleteResponse;
-import com.gdg.linking.domain.item.dto.response.ItemGetResponse;
-import com.gdg.linking.domain.item.dto.response.ItemUpdateResponse;
+import com.gdg.linking.domain.item.dto.response.*;
 
 import java.util.List;
+import java.util.Map;
 
 public interface ItemService {
 
@@ -21,4 +19,13 @@ public interface ItemService {
     ItemDeleteResponse deleteItem(Long itemId, Long userId);
 
     List<ItemGetResponse> getMyItems(Long userId);
+
+
+    void addRelatedLink(Long fromId, Long toId);
+
+    void disconnectItems(Long fromId, Long toId, Long userId);
+
+    Map<String, List<RelatedItemResponse>> getAllRelatedLinks(Long itemId);
+
+    List<ItemGetResponse> getByFolderId(Long folderId);
 }

--- a/src/main/java/com/gdg/linking/domain/item/ItemServiceImpl.java
+++ b/src/main/java/com/gdg/linking/domain/item/ItemServiceImpl.java
@@ -68,6 +68,7 @@ public class ItemServiceImpl implements ItemService{
     }
 
 
+    //아이템 단일 조회
     @Override
     @Transactional
     public ItemGetResponse getItem(Long itemId) {
@@ -83,6 +84,7 @@ public class ItemServiceImpl implements ItemService{
                 .memo(item.getMemo())
                 .importance(item.isImportance())
                 .deadline(item.getDeadline())
+                .createdAt(item.getCreatedAt())
                 .build();
 
         return response;
@@ -152,6 +154,7 @@ public class ItemServiceImpl implements ItemService{
         return response;
     }
 
+    //아이템 전체 조회
     @Transactional
     @Override
     public List<ItemGetResponse> getMyItems(Long userId) {
@@ -168,6 +171,7 @@ public class ItemServiceImpl implements ItemService{
                         .importance(item.isImportance())
                         .deadline(item.getDeadline())
                         // 태그 기능이 완성되면 여기에 추가 로직 작성
+                        .createdAt(item.getCreatedAt())
                         .tags(new ArrayList<>())
                         .build())
                 .collect(Collectors.toList());
@@ -188,6 +192,7 @@ public class ItemServiceImpl implements ItemService{
         }
 
         fromItem.addRelation(toItem);
+
     }
 
 
@@ -209,7 +214,7 @@ public class ItemServiceImpl implements ItemService{
 
     @Override
     @Transactional
-    public Map<String, List<RelatedItemResponse>> getAllRelatedLinks(Long itemId) {
+    public List<RelatedItemResponse> getAllRelatedLinks(Long itemId) {
         Item item = itemRepository.findById(itemId)
                 .orElseThrow(() -> new IllegalArgumentException("아이템이 없습니다."));
 
@@ -223,23 +228,36 @@ public class ItemServiceImpl implements ItemService{
                 .map(RelatedItemResponse::fromEntity) // 여기도 마찬가지!
                 .collect(Collectors.toList());
 
-        Map<String, List<RelatedItemResponse>> response = new HashMap<>();
-        response.put("references", following);   // 내가 참고하는 링크
-        response.put("referencedBy", followedBy); // 나를 참고하는 링크
+        List<RelatedItemResponse> response = new ArrayList<>();
+        response.addAll(following);
+        response.addAll(followedBy);
 
         return response;
     }
 
+
+    //폴더 id로 아이템 조회
     @Transactional
     @Override
-    public List<ItemGetResponse> getByFolderId(Long folderId) {
+    public List<ItemGetResponse> getByFolderId(Long fId) {
 
 
+        List<Item> items = itemRepository.findByFolder_fId(fId);
 
-        List<ItemGetResponse> responses = itemRepository.findByFolderId(folderId);
+        List<ItemGetResponse> response = items.stream()
+                .map(item -> ItemGetResponse.builder()
+                        .itemId(item.getItemId())
+                        .url(item.getUrl())
+                        .title(item.getTitle())
+                        .memo(item.getMemo())
+                        .importance(item.isImportance())
+                        .deadline(item.getDeadline())
+                        .tags(new ArrayList<>()) // 필요 시 태그 로직 추가
+                        .createdAt(item.getCreatedAt())
+                        .build())
+                .collect(Collectors.toList());
 
-
-        return responses;
+        return response;
     }
 
 }

--- a/src/main/java/com/gdg/linking/domain/item/ItemServiceImpl.java
+++ b/src/main/java/com/gdg/linking/domain/item/ItemServiceImpl.java
@@ -4,12 +4,10 @@ import com.gdg.linking.domain.folder.Folder;
 import com.gdg.linking.domain.folder.FolderRepository;
 import com.gdg.linking.domain.item.dto.request.ItemCreateRequest;
 import com.gdg.linking.domain.item.dto.request.ItemUpdateRequest;
-import com.gdg.linking.domain.item.dto.response.ItemCreateResponse;
-import com.gdg.linking.domain.item.dto.response.ItemDeleteResponse;
-import com.gdg.linking.domain.item.dto.response.ItemGetResponse;
-import com.gdg.linking.domain.item.dto.response.ItemUpdateResponse;
+import com.gdg.linking.domain.item.dto.response.*;
 import com.gdg.linking.domain.user.User;
 import com.gdg.linking.domain.user.UserRepository;
+import jakarta.persistence.EntityNotFoundException;
 import jakarta.transaction.Transactional;
 import lombok.Data;
 import lombok.RequiredArgsConstructor;
@@ -19,13 +17,16 @@ import java.nio.file.AccessDeniedException;
 import java.time.LocalDate;
 import java.time.LocalDateTime;
 import java.util.ArrayList;
+import java.util.HashMap;
 import java.util.List;
+import java.util.Map;
 import java.util.stream.Collectors;
 
 
 @Service
 @RequiredArgsConstructor
 public class ItemServiceImpl implements ItemService{
+
 
     private final UserRepository userRepository;
 
@@ -172,5 +173,73 @@ public class ItemServiceImpl implements ItemService{
                 .collect(Collectors.toList());
     }
 
+    @Override
+    @Transactional
+    public void addRelatedLink(Long fromId, Long toId) {
+        // 본인 확인 로직 등은 생략
+        Item fromItem = itemRepository.findById(fromId)
+                .orElseThrow(() -> new EntityNotFoundException("기준 아이템 없음"));
+        Item toItem = itemRepository.findById(toId)
+                .orElseThrow(() -> new EntityNotFoundException("대상 아이템 없음"));
+
+        // 자기 자신을 연결하는 것 방지
+        if (fromId.equals(toId)) {
+            throw new IllegalArgumentException("자기 자신은 연결할 수 없습니다.");
+        }
+
+        fromItem.addRelation(toItem);
+    }
+
+
+    @Override
+    @Transactional
+    public void disconnectItems(Long fromId, Long toId, Long userId) {
+        Item fromItem = itemRepository.findById(fromId)
+                .orElseThrow(() -> new IllegalArgumentException("아이템을 찾을 수 없습니다."));
+        Item toItem = itemRepository.findById(toId)
+                .orElseThrow(() -> new IllegalArgumentException("대상 아이템을 찾을 수 없습니다."));
+
+        // 권한 확인 (본인 아이템인지)
+        if (!fromItem.getUser().getUserId().equals(userId)) {
+            throw new IllegalArgumentException("수정 권한이 없습니다.");
+        }
+
+        fromItem.removeRelation(toItem); // 리스트에서 제거하면 DB 테이블에서도 삭제됨
+    }
+
+    @Override
+    @Transactional
+    public Map<String, List<RelatedItemResponse>> getAllRelatedLinks(Long itemId) {
+        Item item = itemRepository.findById(itemId)
+                .orElseThrow(() -> new IllegalArgumentException("아이템이 없습니다."));
+
+        // 1. 내가 연결한 아이템들 (To)
+        List<RelatedItemResponse> following = item.getRelatedItems().stream()
+                .map(RelatedItemResponse::fromEntity) // RelatedItemResponse의 메서드를 호출!
+                .collect(Collectors.toList());
+
+        // 2. 나를 연결한 아이템들 (From)
+        List<RelatedItemResponse> followedBy = itemRepository.findItemsLinkingToMe(itemId).stream()
+                .map(RelatedItemResponse::fromEntity) // 여기도 마찬가지!
+                .collect(Collectors.toList());
+
+        Map<String, List<RelatedItemResponse>> response = new HashMap<>();
+        response.put("references", following);   // 내가 참고하는 링크
+        response.put("referencedBy", followedBy); // 나를 참고하는 링크
+
+        return response;
+    }
+
+    @Transactional
+    @Override
+    public List<ItemGetResponse> getByFolderId(Long folderId) {
+
+
+
+        List<ItemGetResponse> responses = itemRepository.findByFolderId(folderId);
+
+
+        return responses;
+    }
 
 }

--- a/src/main/java/com/gdg/linking/domain/item/dto/request/RelatedDeleteRequest.java
+++ b/src/main/java/com/gdg/linking/domain/item/dto/request/RelatedDeleteRequest.java
@@ -1,0 +1,18 @@
+package com.gdg.linking.domain.item.dto.request;
+
+import io.swagger.v3.oas.annotations.media.Schema;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+@Getter
+@NoArgsConstructor
+public class RelatedDeleteRequest {
+
+    @Schema(description = "아이템 고유 번호", example = "1")
+    private Long itemId;
+
+    @Schema(description = "연결할 아이템 고유 번호", example = "3")
+    private Long linkItemId;
+
+
+}

--- a/src/main/java/com/gdg/linking/domain/item/dto/request/RelatedItemRequest.java
+++ b/src/main/java/com/gdg/linking/domain/item/dto/request/RelatedItemRequest.java
@@ -1,0 +1,20 @@
+package com.gdg.linking.domain.item.dto.request;
+
+import io.swagger.v3.oas.annotations.media.Schema;
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+@Getter
+@NoArgsConstructor
+@Schema(description = "연결 아이템 정보")
+public class RelatedItemRequest {
+
+    @Schema(description = "아이템 고유 번호", example = "1")
+    private Long itemId;
+
+    @Schema(description = "연결할 아이템 고유 번호", example = "4")
+    private Long linkItemId;
+
+}

--- a/src/main/java/com/gdg/linking/domain/item/dto/response/ItemGetResponse.java
+++ b/src/main/java/com/gdg/linking/domain/item/dto/response/ItemGetResponse.java
@@ -4,6 +4,7 @@ import io.swagger.v3.oas.annotations.media.Schema;
 import lombok.*;
 
 import java.time.LocalDate;
+import java.time.LocalDateTime;
 import java.util.List;
 
 @Setter
@@ -39,6 +40,7 @@ public class ItemGetResponse {
     @Schema(description = "완료 및 리마인드 기한", example = "2026-01-20")
     private LocalDate deadline;
 
-
+    @Schema(description = "저장 날짜", example = "2026-01-20T21:09:00")
+    private LocalDateTime createdAt;
 
 }

--- a/src/main/java/com/gdg/linking/domain/item/dto/response/ItemGetResponse.java
+++ b/src/main/java/com/gdg/linking/domain/item/dto/response/ItemGetResponse.java
@@ -39,4 +39,6 @@ public class ItemGetResponse {
     @Schema(description = "완료 및 리마인드 기한", example = "2026-01-20")
     private LocalDate deadline;
 
+
+
 }

--- a/src/main/java/com/gdg/linking/domain/item/dto/response/RelatedItemResponse.java
+++ b/src/main/java/com/gdg/linking/domain/item/dto/response/RelatedItemResponse.java
@@ -1,0 +1,22 @@
+package com.gdg.linking.domain.item.dto.response;
+
+import com.gdg.linking.domain.item.Item;
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Getter;
+
+@Getter
+@Builder
+@AllArgsConstructor
+public class RelatedItemResponse {
+    private Long itemId;
+    private String title;
+
+    // 엔티티에서 필요한 정보만 추출하는 정적 메서드
+    public static RelatedItemResponse fromEntity(Item item) {
+        return RelatedItemResponse.builder()
+                .itemId(item.getItemId())
+                .title(item.getTitle())
+                .build();
+    }
+}

--- a/src/main/resources/application.yml
+++ b/src/main/resources/application.yml
@@ -11,6 +11,8 @@ spring:
     password: ${RDS_PASSWORD}
 
 
+
+
   jpa:
     hibernate:
       ddl-auto: update # 엔티티 수정을 DB 테이블에 자동으로 반영해줍니다.


### PR DESCRIPTION
## PR 제목

### PR을 한 이유 🎯

- 아이템 간의 관계를 설정하여 연결하는 기능을 구현했습니다

### 이슈 번호 📎

#17 

### 변경사항 🛠

- 연관 링크(Related Link) CRUD 구현

  - POST /item/link: 두 아이템 간의 연관 관계 생성 (중복 연결 방지 로직 포함).

  - GET /item/link/{itemId}: 특정 아이템의 모든 연관 링크 조회 (방향 구분 없이 통합 리스트 반환).

  - DELETE /item/link: 아이템 간 연결 해제 기능.

- JPA & JPQL 버그 수정

  - Folder 엔티티의 필드명 대소문자 매핑 오류(fId) 수정 및 언더바(_)를 활용한 경로 명시.

