### PR TITLE
feat: 캘린더 조회 기능 구현

### DIFF
--- a/src/main/java/com/gdg/linking/domain/calendar/CalendarController.java
+++ b/src/main/java/com/gdg/linking/domain/calendar/CalendarController.java
@@ -1,0 +1,83 @@
+package com.gdg.linking.domain.calendar;
+
+
+import com.gdg.linking.domain.calendar.dto.request.CalendarPageRequest;
+import com.gdg.linking.domain.calendar.dto.response.CalendarMonthResponse;
+import com.gdg.linking.domain.calendar.dto.response.CalendarPageResponse;
+import com.gdg.linking.global.aop.LoginCheck;
+import io.swagger.v3.oas.annotations.Operation;
+import io.swagger.v3.oas.annotations.Parameter;
+import io.swagger.v3.oas.annotations.media.Content;
+import io.swagger.v3.oas.annotations.media.Schema;
+import io.swagger.v3.oas.annotations.responses.ApiResponse;
+import io.swagger.v3.oas.annotations.responses.ApiResponses;
+import io.swagger.v3.oas.annotations.tags.Tag;
+import jakarta.servlet.http.HttpSession;
+import lombok.RequiredArgsConstructor;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.RequestBody;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RestController;
+
+import static com.gdg.linking.global.utils.SessionUtil.getLoginUserId;
+
+@Tag(name = "Calendar", description = "캘린더 및 일정 관리 API") // API 그룹화
+@RestController
+@RequiredArgsConstructor
+@RequestMapping("/api/v1") // 예시 경로
+public class CalendarController {
+
+    private final CalendarService calendarService;
+
+
+    @Operation(
+            summary = "캘린더 데이터 조회",
+            description = "nav바에서 클릭 하자마자 특정 연도와 월을 입력받아 해당 월의 요약 정보(점)와 상세 일정 리스트를 반환합니다."
+    )
+    @ApiResponses(value = {
+            @ApiResponse(responseCode = "200", description = "조회 성공",
+                    content = @Content(schema = @Schema(implementation = CalendarPageResponse.class))),
+            @ApiResponse(responseCode = "401", description = "로그인 필요 (@LoginCheck)", content = @Content),
+            @ApiResponse(responseCode = "400", description = "잘못된 요청 파라미터", content = @Content)
+    })
+    @LoginCheck
+    @PostMapping("/calendar")
+    public ResponseEntity<CalendarPageResponse> getCalendar(
+            @io.swagger.v3.oas.annotations.parameters.RequestBody(description = "조회하고자 하는 연도와 월 정보")
+            @RequestBody CalendarPageRequest request,
+            @Parameter(hidden = true) HttpSession session){ // 세션은 문서에서 숨김
+
+        Long userId = getLoginUserId(session);
+
+         CalendarPageResponse response = calendarService.getCalendarPageData(request, userId);
+         return ResponseEntity.ok(response);
+
+    }
+
+    @Operation(
+            summary = "월별 캘린더 데이터 조회",
+            description = "월을 옮길때마다 특정 년도와 월을 입력받습니다"
+    )
+    @ApiResponses(value = {
+            @ApiResponse(responseCode = "200", description = "조회 성공",
+                    content = @Content(schema = @Schema(implementation = CalendarPageResponse.class))),
+            @ApiResponse(responseCode = "401", description = "로그인 필요 (@LoginCheck)", content = @Content),
+            @ApiResponse(responseCode = "400", description = "잘못된 요청 파라미터", content = @Content)
+    })
+    @LoginCheck
+    @PostMapping("/calendar/mon")
+    public ResponseEntity<CalendarMonthResponse> getMonCalendar(
+            @io.swagger.v3.oas.annotations.parameters.RequestBody(description = "조회하고자 하는 연도와 월 정보")
+            @RequestBody CalendarPageRequest request,
+            @Parameter(hidden = true) HttpSession session){ // 세션은 문서에서 숨김
+
+        Long userId = getLoginUserId(session);
+
+        CalendarMonthResponse response = calendarService.getCalendarMonthData(request, userId);
+        return ResponseEntity.ok(response);
+
+    }
+
+
+}

--- a/src/main/java/com/gdg/linking/domain/calendar/CalendarService.java
+++ b/src/main/java/com/gdg/linking/domain/calendar/CalendarService.java
@@ -1,0 +1,11 @@
+package com.gdg.linking.domain.calendar;
+
+import com.gdg.linking.domain.calendar.dto.request.CalendarPageRequest;
+import com.gdg.linking.domain.calendar.dto.response.CalendarMonthResponse;
+import com.gdg.linking.domain.calendar.dto.response.CalendarPageResponse;
+
+public interface CalendarService {
+    CalendarPageResponse getCalendarPageData(CalendarPageRequest request, Long userId);
+
+    CalendarMonthResponse getCalendarMonthData(CalendarPageRequest request, Long userId);
+}

--- a/src/main/java/com/gdg/linking/domain/calendar/CalendarServiceImpl.java
+++ b/src/main/java/com/gdg/linking/domain/calendar/CalendarServiceImpl.java
@@ -1,0 +1,102 @@
+package com.gdg.linking.domain.calendar;
+
+
+import com.gdg.linking.domain.calendar.dto.request.CalendarPageRequest;
+import com.gdg.linking.domain.calendar.dto.response.CalendarMonthResponse;
+import com.gdg.linking.domain.calendar.dto.response.CalendarPageResponse;
+import com.gdg.linking.domain.calendar.dto.response.CalendarSummaryDto;
+import com.gdg.linking.domain.calendar.dto.response.EventDetailDto;
+import com.gdg.linking.domain.item.Item;
+import com.gdg.linking.domain.item.ItemRepository;
+import jakarta.transaction.Transactional;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+
+import java.time.LocalDate;
+import java.time.LocalDateTime;
+import java.util.List;
+import java.util.stream.Collectors;
+import java.util.stream.Stream;
+
+@RequiredArgsConstructor
+@Service
+public class CalendarServiceImpl implements CalendarService {
+
+    private final ItemRepository itemRepository;
+
+    @Transactional
+    @Override
+    public CalendarPageResponse getCalendarPageData(CalendarPageRequest request, Long userId) {
+
+        // 1. 해당 월의 시작일과 종료일 계산
+        LocalDate startLocalDate = LocalDate.of(request.getYear(), request.getMonth(), 1);
+        LocalDate endLocalDate = startLocalDate.withDayOfMonth(startLocalDate.lengthOfMonth());
+
+        // LocalDateTime 범위 (생성일 조회용)
+        LocalDateTime startDateTime = startLocalDate.atStartOfDay();
+        LocalDateTime endDateTime = endLocalDate.atTime(23, 59, 59);
+
+        // 2. DB에서 데이터 조회
+        // 마감일(Deadline) 기준 데이터 (빨간 점 및 리스트용)
+        List<Item> deadlineItems = itemRepository.findByUser_UserIdAndDeadlineBetweenOrderByDeadlineAsc(
+                userId, startLocalDate, endLocalDate);
+
+        // 생성일(CreatedAt) 기준 데이터 (노란 점용)
+        List<Item> createdItems = itemRepository.findByUser_UserIdAndCreatedAtBetween(
+                userId, startDateTime, endDateTime);
+
+        // 3. DTO 변환 (기존에 만든 정적 메서드 활용)
+        List<CalendarSummaryDto> summary = Stream.concat(
+                deadlineItems.stream().map(CalendarSummaryDto::from),
+                createdItems.stream().map(CalendarSummaryDto::from)
+        ).distinct().collect(Collectors.toList()); // 중복 제거
+
+        List<EventDetailDto> eventList = deadlineItems.stream()
+                .map(EventDetailDto::from)
+                .collect(Collectors.toList());
+
+        // 4. 최종 응답 반환
+        return CalendarPageResponse.builder()
+                .year(request.getYear())
+                .month(request.getMonth())
+                .calendarSummary(summary)
+                .eventList(eventList)
+                .build();
+    }
+
+    @Transactional
+    @Override
+    public CalendarMonthResponse getCalendarMonthData(CalendarPageRequest request, Long userId) {
+
+        LocalDate startLocalDate = LocalDate.of(request.getYear(), request.getMonth(), 1);
+        LocalDate endLocalDate = startLocalDate.withDayOfMonth(startLocalDate.lengthOfMonth());
+
+
+        // LocalDateTime 범위 (생성일 조회용)
+        LocalDateTime startDateTime = startLocalDate.atStartOfDay();
+        LocalDateTime endDateTime = endLocalDate.atTime(23, 59, 59);
+
+        // 2. DB에서 데이터 조회
+        // 마감일(Deadline) 기준 데이터 (빨간 점 및 리스트용)
+        List<Item> deadlineItems = itemRepository.findByUser_UserIdAndDeadlineBetweenOrderByDeadlineAsc(
+                userId, startLocalDate, endLocalDate);
+
+        // 생성일(CreatedAt) 기준 데이터 (노란 점용)
+        List<Item> createdItems = itemRepository.findByUser_UserIdAndCreatedAtBetween(
+                userId, startDateTime, endDateTime);
+
+
+        // 3. DTO 변환 (기존에 만든 정적 메서드 활용)
+        List<CalendarSummaryDto> summary = Stream.concat(
+                deadlineItems.stream().map(CalendarSummaryDto::from),
+                createdItems.stream().map(CalendarSummaryDto::from)
+        ).distinct().collect(Collectors.toList()); // 중복 제거
+
+        return CalendarMonthResponse.builder()
+                .year(request.getYear())
+                .month(request.getMonth())
+                .calendarSummary(summary)
+                .build();
+    }
+
+}

--- a/src/main/java/com/gdg/linking/domain/calendar/dto/request/CalendarPageRequest.java
+++ b/src/main/java/com/gdg/linking/domain/calendar/dto/request/CalendarPageRequest.java
@@ -1,0 +1,18 @@
+package com.gdg.linking.domain.calendar.dto.request;
+
+import lombok.Setter;
+import io.swagger.v3.oas.annotations.media.Schema;
+import lombok.Getter;
+
+
+@Getter
+@Setter
+@Schema(description = "월별 캘린더 조회를 위한 요청 객체")
+public class CalendarPageRequest {
+
+    @Schema(description = "조회하고자 하는 연도", example = "2026")
+    private int year;
+
+    @Schema(description = "조회하고자 하는 월 (1~12)", example = "1", minimum = "1", maximum = "12", requiredMode = Schema.RequiredMode.REQUIRED)
+    private int month;
+}

--- a/src/main/java/com/gdg/linking/domain/calendar/dto/response/CalendarMonthResponse.java
+++ b/src/main/java/com/gdg/linking/domain/calendar/dto/response/CalendarMonthResponse.java
@@ -1,0 +1,21 @@
+package com.gdg.linking.domain.calendar.dto.response;
+
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+import java.util.List;
+
+@Getter
+@Builder
+@NoArgsConstructor
+@AllArgsConstructor
+public class CalendarMonthResponse {
+
+    private int year;
+    private int month;
+    // 상단 캘린더 점(Dot) 표시를 위한 요약 리스트
+    private List<CalendarSummaryDto> calendarSummary;
+
+}

--- a/src/main/java/com/gdg/linking/domain/calendar/dto/response/CalendarPageResponse.java
+++ b/src/main/java/com/gdg/linking/domain/calendar/dto/response/CalendarPageResponse.java
@@ -1,0 +1,20 @@
+package com.gdg.linking.domain.calendar.dto.response;
+
+import lombok.*;
+import java.util.List;
+
+@Getter
+@Builder
+@NoArgsConstructor
+@AllArgsConstructor
+public class CalendarPageResponse {
+    private int year;
+    private int month;
+    // 상단 캘린더 점(Dot) 표시를 위한 요약 리스트
+    private List<CalendarSummaryDto> calendarSummary;
+
+    // 하단 상세 정보를 보여주기 위한 이벤트 리스트
+    private List<EventDetailDto> eventList;
+
+
+}

--- a/src/main/java/com/gdg/linking/domain/calendar/dto/response/CalendarSummaryDto.java
+++ b/src/main/java/com/gdg/linking/domain/calendar/dto/response/CalendarSummaryDto.java
@@ -1,0 +1,31 @@
+package com.gdg.linking.domain.calendar.dto.response;
+
+import com.gdg.linking.domain.item.Item;
+import lombok.Builder;
+import lombok.Getter;
+
+import java.time.LocalDate;
+import java.time.LocalDateTime;
+
+@Getter
+@Builder
+public class CalendarSummaryDto {
+    private Long itemId;
+    private String title;
+
+    // 노란색 점(생성일) 표시용
+    private LocalDateTime createdAtDate;
+
+    // 빨간색 점(데드라인) 표시용
+    private LocalDate deadline;
+
+    // 엔티티로부터 DTO를 생성하는 정적 메서드
+    public static CalendarSummaryDto from(Item item) {
+        return CalendarSummaryDto.builder()
+                .itemId(item.getItemId())
+                .title(item.getTitle())
+                .createdAtDate(item.getCreatedAt())
+                .deadline(item.getDeadline())
+                .build();
+    }
+}

--- a/src/main/java/com/gdg/linking/domain/calendar/dto/response/EventDetailDto.java
+++ b/src/main/java/com/gdg/linking/domain/calendar/dto/response/EventDetailDto.java
@@ -1,0 +1,42 @@
+package com.gdg.linking.domain.calendar.dto.response;
+
+import com.gdg.linking.domain.item.Item;
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+import java.time.LocalDate;
+
+@Getter
+@Builder
+@NoArgsConstructor
+@AllArgsConstructor
+public class EventDetailDto {
+    private Long itemId;
+    private String title;
+    private String memo;
+
+    // 이미지에 있는 #패션 등의 태그 (현재 엔티티에 미구현이므로 폴더명 등으로 대체 가능)
+    private String tag;
+
+    // 프론트엔드에서 D-1 등을 계산하기 위한 원본 날짜
+    private LocalDate deadline;
+
+    // 별점 표시 (이미지의 별 UI 대응용, 엔티티에 중요도 importance가 있으므로 이를 활용)
+    private boolean importance;
+
+    /**
+     * Item 엔티티를 DTO로 변환하는 정적 팩토리 메서드
+     */
+    public static EventDetailDto from(Item item) {
+        return EventDetailDto.builder()
+                .itemId(item.getItemId())
+                .title(item.getTitle())
+                .memo(item.getMemo())
+                .tag(item.getFolder() != null ? item.getFolder().getFolderName() : "기본") // 폴더명을 태그로 우선 활용
+                .deadline(item.getDeadline())
+                .importance(item.isImportance())
+                .build();
+    }
+}

--- a/src/main/java/com/gdg/linking/domain/item/ItemContoller.java
+++ b/src/main/java/com/gdg/linking/domain/item/ItemContoller.java
@@ -28,9 +28,9 @@ import static com.gdg.linking.global.utils.SessionUtil.getLoginUserId;
 @RequestMapping("item")
 public class ItemContoller {
 
-    private final ItemServiceImpl itemService;
+    private final ItemService itemService;
 
-    public ItemContoller(ItemServiceImpl itemService) {
+    public ItemContoller(ItemService itemService) {
         this.itemService = itemService;
     }
 

--- a/src/main/java/com/gdg/linking/domain/item/ItemRepository.java
+++ b/src/main/java/com/gdg/linking/domain/item/ItemRepository.java
@@ -5,6 +5,8 @@ import org.springframework.data.jpa.repository.JpaRepository;
 import org.springframework.data.jpa.repository.Query;
 import org.springframework.data.repository.query.Param;
 
+import java.time.LocalDate;
+import java.time.LocalDateTime;
 import java.util.List;
 
 public interface ItemRepository extends JpaRepository<Item, Long>{
@@ -16,4 +18,12 @@ public interface ItemRepository extends JpaRepository<Item, Long>{
     List<Item> findItemsLinkingToMe(@Param("itemId") Long itemId);
 
     List<Item> findByFolder_fId(Long fId);
+
+    // 특정 사용자의 아이템 중, deadline이 특정 기간 사이인 데이터 조회 (마감일순 정렬)
+    List<Item> findByUser_UserIdAndDeadlineBetweenOrderByDeadlineAsc(
+            Long userId, LocalDate start, LocalDate end);
+
+    // 특정 사용자의 아이템 중, 생성일이 특정 기간 사이인 데이터 조회
+    List<Item> findByUser_UserIdAndCreatedAtBetween(
+            Long userId, LocalDateTime start, LocalDateTime end);
 }

--- a/src/main/java/com/gdg/linking/domain/item/ItemServiceImpl.java
+++ b/src/main/java/com/gdg/linking/domain/item/ItemServiceImpl.java
@@ -168,7 +168,7 @@ public class ItemServiceImpl implements ItemService{
                 .map(item -> ItemGetResponse.builder()
                         .itemId(item.getItemId())
                         .url(item.getUrl())
-                        .folderId(item.getFolder().getFId()) 
+                        .folderId(item.getFolder() != null ? item.getFolder().getFId() : null )
                         .title(item.getTitle())
                         .memo(item.getMemo())
                         .importance(item.isImportance())

--- a/src/main/java/com/gdg/linking/domain/user/UserController.java
+++ b/src/main/java/com/gdg/linking/domain/user/UserController.java
@@ -31,9 +31,9 @@ import static com.gdg.linking.global.utils.SessionUtil.setLoginUserId;
 public class UserController {
 
 
-    private final UserServiceImpl userService;
+    private final UserService userService;
 
-    public UserController(UserServiceImpl userService) {
+    public UserController(UserService userService) {
         this.userService = userService;
     }
 

--- a/src/main/resources/application.yml
+++ b/src/main/resources/application.yml
@@ -11,8 +11,6 @@ spring:
     password: ${RDS_PASSWORD}
 
 
-
-
   jpa:
     hibernate:
       ddl-auto: update # 엔티티 수정을 DB 테이블에 자동으로 반영해줍니다.


### PR DESCRIPTION

## PR 제목

### PR을 한 이유 🎯

- 사용자, 월별 아이템 조회
- 캘린더 아래에 아이템을 마감일 오름차순으로 정렬

### 이슈 번호 📎


- ✅ Feature : 캘린더 할일 조회 [#20](url)


### 변경사항 🛠

- Calendar 패키지 추가
- ItemController에서 상속받던 서비스 객체 변경  



