### PR TITLE
feat : folder 하위 아이템 개수 조회 기능 추가

### DIFF
--- a/src/main/java/com/gdg/linking/domain/folder/FolderServiceImpl.java
+++ b/src/main/java/com/gdg/linking/domain/folder/FolderServiceImpl.java
@@ -133,6 +133,8 @@ public class FolderServiceImpl implements FolderService {
                 .createdAt(createdAt)
                 .displayTime(displayTime)
                 .childCount(folder.getChildFolders().size())
+                //item 갯수 조회
+                .itemCount(folder.getItems().size())
                 .children(new ArrayList<>())
                 .build();
     }

--- a/src/main/java/com/gdg/linking/domain/folder/dto/FolderResponse.java
+++ b/src/main/java/com/gdg/linking/domain/folder/dto/FolderResponse.java
@@ -32,6 +32,14 @@ public class FolderResponse {
     @Schema(description = "하위 폴더 수", example = "3")
     private int childCount;
 
+    @Schema(description = "속한 링크(아이템) 수", example = "15")
+    private int itemCount; // item 갯수 추가
+
+    @Schema(description = "폴더 + 아이템 합계", example = "18")
+    public int getTotalCount() {
+        return this.childCount + this.itemCount;
+    }
+
     // 트리 구조를 위한 코드
     @Builder.Default
     @Schema(description = "하위 폴더 목록")


### PR DESCRIPTION


## PR 제목

### PR을 한 이유 🎯

- 사용자에게 폴더별 아래에 아이템들이 몇개 있는지 보여주기 위해서 코드 추가

### 이슈 번호 📎

- #32 

### 변경사항 🛠

- 아이템, 폴더 개수 조회
- 응답 DTO에 필드 하나만 추가했음

### 특이사항 📌

- 데이터가 많아지면 최적화가 필요함 
- 현재는 간단한 조회 코드만 작성

