### PR TITLE
fix : 캘린더에서 tag 내용 안나오는 문제 수정

### DIFF
--- a/src/main/java/com/gdg/linking/domain/calendar/CalendarServiceImpl.java
+++ b/src/main/java/com/gdg/linking/domain/calendar/CalendarServiceImpl.java
@@ -11,6 +11,7 @@ import org.springframework.stereotype.Service;
 import java.time.LocalDate;
 import java.time.LocalDateTime;
 import java.time.LocalTime;
+import java.util.Collections;
 import java.util.List;
 import java.util.Map;
 import java.util.TreeMap;
@@ -83,6 +84,11 @@ public class CalendarServiceImpl implements CalendarService {
                         .memo(item.getMemo()) // DTO에 정의한 필드 추가
                         .deadline(item.getDeadline())
                         .createdAt(item.getCreatedAt())
+                        .tag(item.getItemTags() != null ?
+                                item.getItemTags().stream()
+                                        .map(itemTag -> itemTag.getTag().getTagName()) // 태그의 이름 추출
+                                        .collect(Collectors.toList())
+                                : Collections.emptyList()) // 태그가 없으면 빈 리스트 반환
                         .importance(item.isImportance())
                         .build())
                 .collect(Collectors.toList());

--- a/src/main/java/com/gdg/linking/domain/calendar/dto/response/CalendarDayResponse.java
+++ b/src/main/java/com/gdg/linking/domain/calendar/dto/response/CalendarDayResponse.java
@@ -1,6 +1,7 @@
 package com.gdg.linking.domain.calendar.dto.response;
 
 import com.gdg.linking.domain.item.Item;
+import com.gdg.linking.domain.tag.ItemTag;
 import lombok.*;
 
 import java.time.LocalDate;
@@ -26,7 +27,7 @@ public class CalendarDayResponse {
         private String memo;
 
         // 이미지에 있는 #패션 등의 태그 (현재 엔티티에 미구현이므로 폴더명 등으로 대체 가능)
-        private String tag;
+        private List<String> tag;
 
         // 프론트엔드에서 D-1 등을 계산하기 위한 원본 날짜
         private LocalDate deadline;

--- a/src/main/java/com/gdg/linking/domain/folder/Folder.java
+++ b/src/main/java/com/gdg/linking/domain/folder/Folder.java
@@ -55,4 +55,6 @@ public class Folder {
     @OnDelete(action = OnDeleteAction.CASCADE)
     @Builder.Default
     private List<Item> items = new ArrayList<>();
+
+
 }

--- a/src/main/java/com/gdg/linking/domain/folder/FolderController.java
+++ b/src/main/java/com/gdg/linking/domain/folder/FolderController.java
@@ -1,6 +1,7 @@
 package com.gdg.linking.domain.folder;
 
 import com.gdg.linking.domain.folder.dto.FolderCreateRequest;
+import com.gdg.linking.domain.folder.dto.FolderMoveRequest;
 import com.gdg.linking.domain.folder.dto.FolderResponse;
 import com.gdg.linking.domain.folder.dto.FolderUpdateRequest;
 import com.gdg.linking.global.aop.LoginCheck;
@@ -16,6 +17,8 @@ import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.*;
 
 import java.util.List;
+
+import static com.gdg.linking.global.utils.SessionUtil.getLoginUserId;
 
 @Tag(name = "Folder", description = "폴더 관련 API")
 @RestController
@@ -107,5 +110,24 @@ public class FolderController {
     public ResponseEntity<Void> deleteFolder(@PathVariable("folder_id") Long folderId) {
         folderService.deleteFolder(folderId);
         return ResponseEntity.noContent().build();
+    }
+
+    @PatchMapping("/move")
+    @Operation(
+            summary = "폴더 이동",
+            description = "특정 폴더를 다른 폴더의 하위로 이동시킵니다. (하위 아이템 및 폴더 포함)",
+            responses = {
+                    @ApiResponse(responseCode = "200", description = "이동 성공"),
+                    @ApiResponse(responseCode = "400", description = "잘못된 요청 (순환 참조 등)")
+            }
+    )
+    public ResponseEntity<FolderResponse> moveFolder(
+            @RequestBody FolderMoveRequest request,
+            HttpSession session) {
+
+        Long userId = getLoginUserId(session);
+        folderService.moveFolders( request, userId);
+
+        return ResponseEntity.ok().build();
     }
 }

--- a/src/main/java/com/gdg/linking/domain/folder/FolderService.java
+++ b/src/main/java/com/gdg/linking/domain/folder/FolderService.java
@@ -1,6 +1,7 @@
 package com.gdg.linking.domain.folder;
 
 import com.gdg.linking.domain.folder.dto.FolderCreateRequest;
+import com.gdg.linking.domain.folder.dto.FolderMoveRequest;
 import com.gdg.linking.domain.folder.dto.FolderResponse;
 import com.gdg.linking.domain.folder.dto.FolderUpdateRequest;
 
@@ -14,4 +15,6 @@ public interface FolderService {
     FolderResponse updateFolder(Long folderId, FolderUpdateRequest request);
 
     void deleteFolder(Long folderId);
+
+    void moveFolders(FolderMoveRequest request, Long userId);
 }

--- a/src/main/java/com/gdg/linking/domain/folder/FolderServiceImpl.java
+++ b/src/main/java/com/gdg/linking/domain/folder/FolderServiceImpl.java
@@ -1,6 +1,7 @@
 package com.gdg.linking.domain.folder;
 
 import com.gdg.linking.domain.folder.dto.FolderCreateRequest;
+import com.gdg.linking.domain.folder.dto.FolderMoveRequest;
 import com.gdg.linking.domain.folder.dto.FolderResponse;
 import com.gdg.linking.domain.folder.dto.FolderUpdateRequest;
 import com.gdg.linking.domain.user.User;
@@ -156,4 +157,61 @@ public class FolderServiceImpl implements FolderService {
                 .children(new ArrayList<>())
                 .build();
     }
+
+
+
+
+    @Override
+    @Transactional
+    public void moveFolders(FolderMoveRequest request, Long userId) {
+        // 1. 목표 폴더(Target Parent) 조회 및 검증
+        Folder targetParent = null;
+        if (request.getParentId() != null) {
+            targetParent = folderRepository.findById(request.getParentId())
+                    .orElseThrow(() -> new IllegalArgumentException("목표 폴더를 찾을 수 없습니다."));
+
+            // 목표 폴더 권한 확인
+            if (!targetParent.getUser().getUserId().equals(userId)) {
+                throw new IllegalArgumentException("목표 폴더에 대한 권한이 없습니다.");
+            }
+        }
+
+        // 2. 이동할 폴더들(Source Folders) 조회
+        List<Folder> sourceFolders = folderRepository.findAllById(request.getFolderIds());
+
+        if (sourceFolders.isEmpty()) {
+            throw new IllegalArgumentException("이동할 폴더가 선택되지 않았습니다.");
+        }
+
+        // 3. 각 폴더에 대해 검증 및 이동 수행
+        for (Folder sourceFolder : sourceFolders) {
+            // 3-1. 권한 확인 (내 폴더가 맞는지)
+            if (!sourceFolder.getUser().getUserId().equals(userId)) {
+                throw new IllegalArgumentException("본인의 폴더만 이동할 수 있습니다. ID: " + sourceFolder.getFId());
+            }
+
+            // 3-2. 자기 자신으로 이동 방지
+            if (targetParent != null && sourceFolder.getFId().equals(targetParent.getFId())) {
+                throw new IllegalArgumentException("자기 자신을 부모로 설정할 수 없습니다.");
+            }
+
+            // 3-3. 순환 참조 방지 (내가 내 자식 밑으로 들어가는지 체크)
+            // 목표 폴더(targetParent)가 현재 이동하려는 폴더(sourceFolder)의 하위인지 확인해야 함
+            if (targetParent != null) {
+                Folder current = targetParent;
+                while (current != null) {
+                    if (current.getFId().equals(sourceFolder.getFId())) {
+                        throw new IllegalArgumentException("자신의 하위 폴더로는 이동할 수 없습니다. 폴더명: " + sourceFolder.getFolderName());
+                    }
+                    current = current.getParentFolder();
+                }
+            }
+
+            // 3-4. 부모 변경 (이동 처리)
+            sourceFolder.setParentFolder(targetParent);
+        }
+
+        // Dirty Checking으로 인해 트랜잭션 종료 시 일괄 UPDATE 쿼리 발생
+    }
+
 }

--- a/src/main/java/com/gdg/linking/domain/folder/dto/FolderMoveRequest.java
+++ b/src/main/java/com/gdg/linking/domain/folder/dto/FolderMoveRequest.java
@@ -1,0 +1,19 @@
+package com.gdg.linking.domain.folder.dto;
+
+import io.swagger.v3.oas.annotations.media.Schema;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+import java.util.List;
+
+@Getter
+@NoArgsConstructor
+@Schema(description = "폴더 이동 요청 DTO")
+public class FolderMoveRequest {
+
+    @Schema(description = "이동할 폴더들의 ID 리스트", example = "[1, 2, 3]")
+    private List<Long> folderIds;
+
+    @Schema(description = "이동할 곳의 상위 폴더 ID (최상위로 이동하려면 null)", example = "10")
+    private Long parentId;
+}

--- a/src/main/java/com/gdg/linking/domain/item/Item.java
+++ b/src/main/java/com/gdg/linking/domain/item/Item.java
@@ -135,4 +135,9 @@ public class Item {
     public void toggleImportance() {
         this.importance = !this.importance;
     }
+
+    // 폴더 이동 편의 메서드
+    public void updateFolder(Folder folder) {
+        this.folder = folder;
+    }
 }

--- a/src/main/java/com/gdg/linking/domain/item/ItemContoller.java
+++ b/src/main/java/com/gdg/linking/domain/item/ItemContoller.java
@@ -1,10 +1,7 @@
 package com.gdg.linking.domain.item;
 
 
-import com.gdg.linking.domain.item.dto.request.ItemCreateRequest;
-import com.gdg.linking.domain.item.dto.request.ItemUpdateRequest;
-import com.gdg.linking.domain.item.dto.request.RelatedDeleteRequest;
-import com.gdg.linking.domain.item.dto.request.RelatedItemRequest;
+import com.gdg.linking.domain.item.dto.request.*;
 import com.gdg.linking.domain.item.dto.response.*;
 import com.gdg.linking.global.aop.LoginCheck;
 import io.swagger.v3.oas.annotations.Operation;
@@ -257,5 +254,22 @@ public class ItemContoller {
         return ResponseEntity.ok(response);
     }
 
+    @LoginCheck
+    @Operation(summary = "아이템 폴더 이동", description = "여러 아이템을 특정 폴더로 일괄 이동합니다.")
+    @ApiResponses(value = {
+            @ApiResponse(responseCode = "200", description = "이동 성공"),
+            @ApiResponse(responseCode = "400", description = "잘못된 요청 (폴더 없음, 권한 없음 등)"),
+            @ApiResponse(responseCode = "401", description = "로그인 필요")
+    })
+    @PatchMapping("/move")
+    public ResponseEntity<Void> moveItems(
+            @RequestBody ItemMoveRequest request,
+            HttpSession session) {
+
+        Long userId = getLoginUserId(session);
+        itemService.moveItemsToFolder(request, userId);
+
+        return ResponseEntity.ok().build();
+    }
 
 }

--- a/src/main/java/com/gdg/linking/domain/item/ItemRepository.java
+++ b/src/main/java/com/gdg/linking/domain/item/ItemRepository.java
@@ -1,6 +1,7 @@
 package com.gdg.linking.domain.item;
 
 import com.gdg.linking.domain.item.dto.response.ItemGetResponse;
+import org.springframework.data.jpa.repository.EntityGraph;
 import org.springframework.data.jpa.repository.JpaRepository;
 import org.springframework.data.jpa.repository.Query;
 import org.springframework.data.repository.query.Param;
@@ -56,6 +57,7 @@ public interface ItemRepository extends JpaRepository<Item, Long>{
             Long userId, LocalDate start, LocalDate end);
 
     // 특정 사용자의 아이템 중, 생성일이 특정 기간 사이인 데이터 조회
+    @EntityGraph(attributePaths = {"itemTags"})
     List<Item> findByUser_UserIdAndCreatedAtBetween(
             Long userId, LocalDateTime start, LocalDateTime end);
 

--- a/src/main/java/com/gdg/linking/domain/item/ItemService.java
+++ b/src/main/java/com/gdg/linking/domain/item/ItemService.java
@@ -1,6 +1,7 @@
 package com.gdg.linking.domain.item;
 
 import com.gdg.linking.domain.item.dto.request.ItemCreateRequest;
+import com.gdg.linking.domain.item.dto.request.ItemMoveRequest;
 import com.gdg.linking.domain.item.dto.request.ItemUpdateRequest;
 import com.gdg.linking.domain.item.dto.response.*;
 
@@ -39,4 +40,6 @@ public interface ItemService {
     List<ItemGetResponse> getByFolderId(Long folderId);
 
     ItemUpdateResponse updateImportance(Long itemId, Long userId, boolean importance);
+
+    void moveItemsToFolder(ItemMoveRequest request, Long userId);
 }

--- a/src/main/java/com/gdg/linking/domain/item/ItemServiceImpl.java
+++ b/src/main/java/com/gdg/linking/domain/item/ItemServiceImpl.java
@@ -3,6 +3,7 @@ package com.gdg.linking.domain.item;
 import com.gdg.linking.domain.folder.Folder;
 import com.gdg.linking.domain.folder.FolderRepository;
 import com.gdg.linking.domain.item.dto.request.ItemCreateRequest;
+import com.gdg.linking.domain.item.dto.request.ItemMoveRequest;
 import com.gdg.linking.domain.item.dto.request.ItemUpdateRequest;
 import com.gdg.linking.domain.item.dto.response.*;
 import com.gdg.linking.domain.notification.NotificationService;
@@ -298,6 +299,7 @@ public class ItemServiceImpl implements ItemService{
                         .url(item.getUrl())
                         .title(item.getTitle())
                         .folderName(item.getFolder() != null ? item.getFolder().getFolderName() : null)
+                        .folderId(item.getFolder() != null ? item.getFolder().getFId() : null)
                         .memo(item.getMemo())
                         .importance(item.isImportance())
                         .deadline(item.getDeadline())
@@ -457,6 +459,36 @@ public class ItemServiceImpl implements ItemService{
                 .build();
     }
 
+    @Transactional
+    @Override
+    public void moveItemsToFolder(ItemMoveRequest request, Long userId) {
+        // 1. 목적지 폴더 조회 및 권한 확인
+        // (폴더 ID가 없거나, 본인 폴더가 아니면 예외 발생)
+        Folder folder = folderRepository.findById(request.getFolderId())
+                .orElseThrow(() -> new IllegalArgumentException("폴더를 찾을 수 없습니다."));
+
+        if (!folder.getUser().getUserId().equals(userId)) {
+            throw new IllegalArgumentException("해당 폴더에 접근 권한이 없습니다.");
+        }
+
+        // 2. 이동할 아이템들 조회
+        List<Item> items = itemRepository.findAllById(request.getItemIds());
+
+        if (items.isEmpty()) {
+            throw new IllegalArgumentException("이동할 아이템이 선택되지 않았습니다.");
+        }
+
+        // 3. 아이템 순회하며 폴더 변경
+        for (Item item : items) {
+            // 보안 체크: 내 아이템이 맞는지 확인
+            if (!item.getUser().getUserId().equals(userId)) {
+                throw new IllegalArgumentException("본인의 아이템만 이동할 수 있습니다. ID: " + item.getItemId());
+            }
+
+            // 폴더 변경 (Dirty Checking으로 인해 트랜잭션 종료 시 자동 UPDATE 쿼리 발생)
+            item.updateFolder(folder);
+        }
+    }
 }
 
 

--- a/src/main/java/com/gdg/linking/domain/item/dto/request/ItemMoveRequest.java
+++ b/src/main/java/com/gdg/linking/domain/item/dto/request/ItemMoveRequest.java
@@ -1,0 +1,19 @@
+package com.gdg.linking.domain.item.dto.request;
+
+import io.swagger.v3.oas.annotations.media.Schema;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+import java.util.List;
+
+@Getter
+@NoArgsConstructor
+@Schema(description = "아이템 폴더 이동 요청 DTO")
+public class ItemMoveRequest {
+
+    @Schema(description = "이동할 아이템들의 ID 리스트", example = "[1, 2, 3]")
+    private List<Long> itemIds;
+
+    @Schema(description = "이동할 목적지 폴더 ID", example = "10")
+    private Long folderId;
+}

--- a/src/main/resources/application.yml
+++ b/src/main/resources/application.yml
@@ -14,9 +14,12 @@ spring:
 
     driver-class-name: com.mysql.cj.jdbc.Driver
 
-    url: jdbc:mysql://gdg-5th-linking-db.clm2ko6ggpgl.ap-northeast-2.rds.amazonaws.com:3306/linking?serverTimezone=Asia/Seoul&useSSL=false&allowPublicKeyRetrieval=true
-    username: admin
-    password: ${RDS_PASSWORD}
+    #url: jdbc:mysql://gdg-5th-linking-db.clm2ko6ggpgl.ap-northeast-2.rds.amazonaws.com:3306/linking?serverTimezone=Asia/Seoul&useSSL=false&allowPublicKeyRetrieval=true
+    #username: admin
+    #password: ${RDS_PASSWORD}
+    url: jdbc:mysql://localhost:3306/db?useSSL=false&serverTimezone=Asia/Seoul&characterEncoding=UTF-8
+    username: root
+    password: 1234
 
 
 


### PR DESCRIPTION


## PR 제목

### PR을 한 이유 🎯

- 태그 기능 구현 이후, 캘린더 조회 API 응답에 tag 정보가 포함되지 않는 문제 수정
- 
### 이슈 번호 📎

- #43 

### 변경사항 🛠

- CalendarItemResponse DTO에 tag 정보 포함

- 관련 쿼리 수정 (EntityGraph추가)

