### PR TITLE
feat: 아이템 카테고리별 검색 기능 구현

### DIFF
--- a/src/main/java/com/gdg/linking/domain/item/Item.java
+++ b/src/main/java/com/gdg/linking/domain/item/Item.java
@@ -25,7 +25,7 @@ import java.util.List;
 public class Item {
 
     public enum ItemStatus {
-        ACTIVE, COMPLETED, TRASH
+        ACTIVE, COMPLETED, TRASH, ORPHAN
     }
 
     @Id
@@ -59,12 +59,15 @@ public class Item {
     @Column(name = "memo")
     private String memo;
 
+    @Builder.Default
     @Column(name = "importance")
     private boolean importance = false;
 
     @Column(name = "deadline")
     private LocalDate deadline;
 
+
+    @Builder.Default
     @Enumerated(EnumType.STRING)
     @Column(name = "status")
     private ItemStatus status = ItemStatus.ACTIVE;
@@ -86,6 +89,7 @@ public class Item {
         this.deletedAt = null;
     }
 
+    @Builder.Default
     @ManyToMany
     @JoinTable(
             name = "item_relations",           // 생성될 중간 테이블 이름

--- a/src/main/java/com/gdg/linking/domain/item/ItemContoller.java
+++ b/src/main/java/com/gdg/linking/domain/item/ItemContoller.java
@@ -56,13 +56,17 @@ public class ItemContoller {
 
     @LoginCheck
     @GetMapping("")
-    @Operation(summary = "내 아이템 목록 조회", description = "필터(upcoming, important, stale, trash, recent,root)를 지원합니다.")
+    @Operation(summary = "내 아이템 목록 조회 및 검색",
+            description = "필터(upcoming, important, stale, trash)와 검색어(keyword)를 조합하여 조회합니다.")
     public ResponseEntity<List<ItemGetResponse>> getMyItems(
-            @RequestParam(value = "filter", required = false) String filter, HttpSession session) {
+            @RequestParam(value = "filter", required = false) String filter,
+            @RequestParam(value = "keyword", required = false) String keyword, // 추가됨
+            HttpSession session) {
 
         Long userId = getLoginUserId(session);
 
-        List<ItemGetResponse> response = itemService.getMyItems(userId, filter);
+        // keyword 파라미터 추가 전달
+        List<ItemGetResponse> response = itemService.getMyItems(userId, filter, keyword);
 
         return ResponseEntity.ok(response);
     }

--- a/src/main/java/com/gdg/linking/domain/item/ItemRepository.java
+++ b/src/main/java/com/gdg/linking/domain/item/ItemRepository.java
@@ -98,4 +98,83 @@ public interface ItemRepository extends JpaRepository<Item, Long>{
 
     // [추가] 특정 사용자의 아이템 중, 폴더가 없는(NULL) 것만 최신순 조회
     List<Item> findByUser_UserIdAndStatusAndFolderIsNullOrderByCreatedAtDesc(Long userId, Item.ItemStatus status);
+
+    // 1. [마감 임박] + [검색]
+    // 조건: 사용자 + 상태(ACTIVE) + 마감일 범위 + (제목 or 태그 검색)
+    @Query("SELECT DISTINCT i FROM Item i " +
+            "LEFT JOIN i.itemTags it " +
+            "LEFT JOIN it.tag t " +
+            "WHERE i.user.userId = :userId " +
+            "AND i.status = :status " +
+            "AND i.deadline BETWEEN :startDate AND :endDate " +
+            "AND (i.title LIKE %:keyword% OR t.tagName LIKE %:keyword%) " +
+            "ORDER BY i.deadline ASC")
+    List<Item> searchUpcomingItems(
+            @Param("userId") Long userId,
+            @Param("startDate") LocalDate startDate,
+            @Param("endDate") LocalDate endDate,
+            @Param("status") Item.ItemStatus status,
+            @Param("keyword") String keyword);
+
+
+    // 2. [중요] + [검색]
+    // 조건: 사용자 + 상태(ACTIVE) + 중요(true) + (제목 or 태그 검색)
+    @Query("SELECT DISTINCT i FROM Item i " +
+            "LEFT JOIN i.itemTags it " +
+            "LEFT JOIN it.tag t " +
+            "WHERE i.user.userId = :userId " +
+            "AND i.status = :status " +
+            "AND i.importance = true " +
+            "AND (i.title LIKE %:keyword% OR t.tagName LIKE %:keyword%) " +
+            "ORDER BY i.createdAt DESC")
+    List<Item> searchImportantItems(
+            @Param("userId") Long userId,
+            @Param("status") Item.ItemStatus status,
+            @Param("keyword") String keyword);
+
+
+    // 3. [청소/Stale] + [검색]
+    // 조건: 사용자 + 상태(ACTIVE) + 50일 이상 경과 + (제목 or 태그 검색)
+    @Query("SELECT DISTINCT i FROM Item i " +
+            "LEFT JOIN i.itemTags it " +
+            "LEFT JOIN it.tag t " +
+            "WHERE i.user.userId = :userId " +
+            "AND i.status = :status " +
+            "AND (COALESCE(i.updatedAt, i.createdAt) < :targetDate) " +
+            "AND (i.title LIKE %:keyword% OR t.tagName LIKE %:keyword%) " +
+            "ORDER BY i.createdAt ASC")
+    List<Item> searchStaleItems(
+            @Param("userId") Long userId,
+            @Param("targetDate") LocalDateTime targetDate,
+            @Param("status") Item.ItemStatus status,
+            @Param("keyword") String keyword);
+
+
+    // 4. [휴지통] + [검색]
+    // 조건: 사용자 + 상태(TRASH) + (제목 or 태그 검색)
+    @Query("SELECT DISTINCT i FROM Item i " +
+            "LEFT JOIN i.itemTags it " +
+            "LEFT JOIN it.tag t " +
+            "WHERE i.user.userId = :userId " +
+            "AND i.status = :status " +
+            "AND (i.title LIKE %:keyword% OR t.tagName LIKE %:keyword%) " +
+            "ORDER BY i.deletedAt DESC")
+    List<Item> searchTrashItems(
+            @Param("userId") Long userId,
+            @Param("status") Item.ItemStatus status,
+            @Param("keyword") String keyword);
+
+
+    // 5. [전체/기본] + [검색] (필터 없을 때 사용)
+    @Query("SELECT DISTINCT i FROM Item i " +
+            "LEFT JOIN i.itemTags it " +
+            "LEFT JOIN it.tag t " +
+            "WHERE i.user.userId = :userId " +
+            "AND i.status = :status " +
+            "AND (i.title LIKE %:keyword% OR t.tagName LIKE %:keyword%) " +
+            "ORDER BY i.createdAt DESC")
+    List<Item> searchAllItems(
+            @Param("userId") Long userId,
+            @Param("status") Item.ItemStatus status,
+            @Param("keyword") String keyword);
 }

--- a/src/main/java/com/gdg/linking/domain/item/ItemService.java
+++ b/src/main/java/com/gdg/linking/domain/item/ItemService.java
@@ -17,8 +17,7 @@ public interface ItemService {
 
     ItemDeleteResponse deleteItem(Long itemId, Long userId);
 
-    List<ItemGetResponse> getMyItems(Long userId, String filter);
-
+    List<ItemGetResponse> getMyItems(Long userId, String filter, String keyword);
     // 휴지통 개별 아이템 영구 삭제
     void hardDeleteOne(Long itemId, Long userId);
 

--- a/src/main/java/com/gdg/linking/domain/item/ItemServiceImpl.java
+++ b/src/main/java/com/gdg/linking/domain/item/ItemServiceImpl.java
@@ -266,38 +266,76 @@ public class ItemServiceImpl implements ItemService{
 
     // 내 아이템 조회
     @Override
-    @Transactional
-    public List<ItemGetResponse> getMyItems(Long userId, String filter) {
+    @Transactional(readOnly = true) // 조회 최적화
+    public List<ItemGetResponse> getMyItems(Long userId, String filter, String keyword) {
         List<Item> items;
 
-        // 마감 임박 (최신순 + ACTIVE 조건)
-        if ("upcoming".equals(filter)) {
-            items = itemRepository.findByUser_UserIdAndDeadlineBetweenAndStatusOrderByDeadlineAsc(
-                    userId, LocalDate.now(), LocalDate.now().plusDays(7), Item.ItemStatus.ACTIVE);
+        // 검색어가 유효한지 확인 (null이 아니고 빈 문자열도 아님)
+        boolean hasKeyword = keyword != null && !keyword.trim().isEmpty();
+
+        // 1. 검색어가 있을 때 (AND 조건 적용)
+        if (hasKeyword) {
+            String searchKeyword = keyword.trim(); // 공백 제거
+
+            if ("upcoming".equals(filter)) {
+                // 마감 임박 + 검색
+                items = itemRepository.searchUpcomingItems(
+                        userId,
+                        LocalDate.now(),
+                        LocalDate.now().plusDays(7),
+                        Item.ItemStatus.ACTIVE,
+                        searchKeyword
+                );
+            } else if ("important".equals(filter)) {
+                // 중요 + 검색
+                items = itemRepository.searchImportantItems(
+                        userId,
+                        Item.ItemStatus.ACTIVE,
+                        searchKeyword
+                );
+            } else if ("stale".equals(filter)) {
+                // 청소(50일 이상) + 검색
+                items = itemRepository.searchStaleItems(
+                        userId,
+                        LocalDateTime.now().minusDays(50),
+                        Item.ItemStatus.ACTIVE,
+                        searchKeyword
+                );
+            } else if ("trash".equals(filter)) {
+                // 휴지통 + 검색
+                items = itemRepository.searchTrashItems(
+                        userId,
+                        Item.ItemStatus.TRASH,
+                        searchKeyword
+                );
+            } else {
+                items = itemRepository.searchAllItems(
+                        userId,
+                        Item.ItemStatus.ACTIVE,
+                        searchKeyword
+                );
+            }
+
         }
-        // 중요 표시 (최신순 + ACTIVE 조건)
-        else if ("important".equals(filter)) {
-            items = itemRepository.findByUser_UserIdAndImportanceTrueAndStatus(userId, Item.ItemStatus.ACTIVE);
-        }
-        // 청소 대상 (최신순 + ACTIVE 조건)
-        else if ("stale".equals(filter)) {
-            items = itemRepository.findStaleItems(
-                    userId, LocalDateTime.now().minusDays(50), Item.ItemStatus.ACTIVE);
-        }
-        // 휴지통 (TRASH 상태 조회 유지)
-        else if ("trash".equals(filter)) {
-            items = itemRepository.findByUser_UserIdAndStatusOrderByDeletedAtDesc(userId, Item.ItemStatus.TRASH);
-        }
-        // 최근 저장 Item 8개 조회 (최신순 + ACTIVE 조건)
-        else if ("recent".equals(filter)) {
-            items = itemRepository.findTop8ByUser_UserIdAndStatusOrderByCreatedAtDesc(userId, Item.ItemStatus.ACTIVE);
-        }
-        else if ("root".equals(filter)) {
-            items = itemRepository.findByUser_UserIdAndStatusAndFolderIsNullOrderByCreatedAtDesc(userId, Item.ItemStatus.ACTIVE);
-        }
-        // 기본 조회 (최신순 + ACTIVE 조건)
+        // 2. 검색어가 없을 때 (기존 로직 유지)
         else {
-            items = itemRepository.findByUser_UserIdAndStatusOrderByCreatedAtDesc(userId, Item.ItemStatus.ACTIVE);
+            if ("upcoming".equals(filter)) {
+                items = itemRepository.findByUser_UserIdAndDeadlineBetweenAndStatusOrderByDeadlineAsc(
+                        userId, LocalDate.now(), LocalDate.now().plusDays(7), Item.ItemStatus.ACTIVE);
+            } else if ("important".equals(filter)) {
+                items = itemRepository.findByUser_UserIdAndImportanceTrueAndStatus(userId, Item.ItemStatus.ACTIVE);
+            } else if ("stale".equals(filter)) {
+                items = itemRepository.findStaleItems(
+                        userId, LocalDateTime.now().minusDays(50), Item.ItemStatus.ACTIVE);
+            } else if ("trash".equals(filter)) {
+                items = itemRepository.findByUser_UserIdAndStatusOrderByDeletedAtDesc(userId, Item.ItemStatus.TRASH);
+            } else if ("recent".equals(filter)) {
+                items = itemRepository.findTop8ByUser_UserIdAndStatusOrderByCreatedAtDesc(userId, Item.ItemStatus.ACTIVE);
+            } else if ("root".equals(filter)) {
+                items = itemRepository.findByUser_UserIdAndStatusAndFolderIsNullOrderByCreatedAtDesc(userId, Item.ItemStatus.ACTIVE);
+            } else {
+                items = itemRepository.findByUser_UserIdAndStatusOrderByCreatedAtDesc(userId, Item.ItemStatus.ACTIVE);
+            }
         }
 
         return items.stream()

--- a/src/main/java/com/gdg/linking/domain/search/SearchController.java
+++ b/src/main/java/com/gdg/linking/domain/search/SearchController.java
@@ -1,12 +1,17 @@
 package com.gdg.linking.domain.search;
 
 
+import com.gdg.linking.domain.item.ItemService;
+import com.gdg.linking.domain.item.dto.response.ItemGetResponse;
 import com.gdg.linking.domain.search.dto.response.SearchResponse;
 import com.gdg.linking.global.aop.LoginCheck;
+import io.swagger.v3.oas.annotations.Operation;
 import jakarta.servlet.http.HttpSession;
 import lombok.RequiredArgsConstructor;
 import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.*;
+
+import java.util.List;
 
 import static com.gdg.linking.global.utils.SessionUtil.getLoginUserId;
 
@@ -17,11 +22,15 @@ public class SearchController {
 
 
     private final SearchService searchService;
+    private final ItemService itemService;
 
-    @GetMapping
+
     @LoginCheck
+    @GetMapping
+    @Operation(summary = "내 아이템 목록 조회", description = "필터(upcoming, important, stale, trash, recent,root)를 지원합니다.")
     public ResponseEntity<SearchResponse> search(
             @RequestParam String keyword,
+            @RequestParam(value = "filter", required = false) String filter,
             @RequestParam(defaultValue = "0") int page,
             @RequestParam(defaultValue = "10") int size,
             HttpSession session

--- a/src/main/java/com/gdg/linking/domain/tag/Tag.java
+++ b/src/main/java/com/gdg/linking/domain/tag/Tag.java
@@ -22,6 +22,7 @@ public class Tag {
     @Column(unique = true, nullable = false)
     private String tagName;
 
+    @Builder.Default
     @OneToMany(mappedBy = "tag")
     private List<ItemTag> postTags = new ArrayList<>();
 

--- a/src/main/java/com/gdg/linking/domain/user/User.java
+++ b/src/main/java/com/gdg/linking/domain/user/User.java
@@ -3,6 +3,7 @@ package com.gdg.linking.domain.user;
 
 import jakarta.persistence.*;
 import lombok.*;
+import org.springframework.core.codec.StringDecoder;
 
 @Entity
 @Table(name="users")
@@ -36,14 +37,24 @@ public class User {
     // 프로필
     @Column(name = "total_xp")
     @Builder.Default
-    private int totalXp = 0;
+    private Integer totalXp = 0;
 
     @Column(name = "level")
     @Builder.Default
-    private int level = 1;
+    private Integer level = 1;
 
     @Column(name = "profile_image")
     @Builder.Default
     private String profileImage = "PAWN";
+
+
+    public void updateNickName(String nickname){
+        this.nickName = nickName;
+    }
+
+
+    public void updatePassword(String password) {
+        this.password = password;
+    }
 
 }

--- a/src/main/java/com/gdg/linking/domain/user/UserController.java
+++ b/src/main/java/com/gdg/linking/domain/user/UserController.java
@@ -1,10 +1,11 @@
 package com.gdg.linking.domain.user;
 
 
-import com.gdg.linking.domain.user.dto.request.UserCreateRequest;
-import com.gdg.linking.domain.user.dto.request.UserLoginRequest;
+import com.gdg.linking.domain.user.dto.request.*;
 import com.gdg.linking.domain.user.dto.response.UserCreateResponse;
+import com.gdg.linking.domain.user.dto.response.UserInfoResponse;
 import com.gdg.linking.domain.user.dto.response.UserLoginResponse;
+import com.gdg.linking.global.aop.LoginCheck;
 import io.swagger.v3.oas.annotations.Operation;
 import io.swagger.v3.oas.annotations.responses.ApiResponse;
 import io.swagger.v3.oas.annotations.responses.ApiResponses;
@@ -13,15 +14,11 @@ import jakarta.servlet.http.HttpSession;
 import jakarta.validation.Valid;
 import org.apache.coyote.Response;
 import org.springframework.http.ResponseEntity;
-import org.springframework.web.bind.annotation.PostMapping;
-import org.springframework.web.bind.annotation.RequestBody;
-import org.springframework.web.bind.annotation.RequestMapping;
-import org.springframework.web.bind.annotation.RestController;
+import org.springframework.web.bind.annotation.*;
 
 import java.net.URI;
 
-import static com.gdg.linking.global.utils.SessionUtil.setLoginAdminId;
-import static com.gdg.linking.global.utils.SessionUtil.setLoginUserId;
+import static com.gdg.linking.global.utils.SessionUtil.*;
 
 //swaager 관련 태그
 @Tag(name = "User", description = "사용자 관련 API")
@@ -95,9 +92,80 @@ public class UserController {
 
     }
 
+    // 설정창 진입 전 비밀번호 확인
+    @LoginCheck
+    @PostMapping("/check-password")
+    @Operation(summary = "비밀번호 확인", description = "마이페이지 접근 전 비밀번호를 확인합니다.")
+    @ApiResponses(value = {
+            @ApiResponse(responseCode = "200", description = "비밀번호 일치"),
+            @ApiResponse(responseCode = "401", description = "비밀번호 불일치")
+    })
+    public ResponseEntity<Boolean> checkPassword(
+            @RequestBody UserCheckPasswordRequest request,
+            HttpSession session
+    ) {
+        Long userId = getLoginUserId(session);
+        // 일치하면 true, 아니면 예외 발생 혹은 false 리턴
+        Boolean isMatch = userService.checkPassword(userId, request.getPassword());
+
+        return ResponseEntity.ok(isMatch);
+    }
+
+    // 설정창에 보여줄 내 정보 조회
+    @LoginCheck
+    @GetMapping("/me")
+    @Operation(summary = "내 정보 조회", description = "설정창에 표시할 사용자 정보를 조회합니다.")
+    public ResponseEntity<UserInfoResponse> getUserInfo(HttpSession session) {
+        Long userId = getLoginUserId(session);
+        UserInfoResponse userInfo = userService.getUserInfo(userId);
+
+        return ResponseEntity.ok(userInfo);
+    }
+
+
+    @LoginCheck
+    @PatchMapping("nickname")
+    @Operation(
+            summary = "닉네임 변경",
+            description = "사용자 닉네임을 변경합니다."
+    )
+    @ApiResponses(value = {
+            @ApiResponse(responseCode = "200", description = "닉네임 변경 성공"),
+            @ApiResponse(responseCode = "401", description = "잘못된 요청 파라미터")
+    })
+    public ResponseEntity<Void> patchNickName(
+            @RequestBody UserPatchNickRequest request,
+            HttpSession session
+            ) {
+
+        Long userId = getLoginUserId(session);
+        userService.patchNickName(userId, request);
+
+        return ResponseEntity.ok().build();
+    }
 
 
 
+    @LoginCheck
+    @PatchMapping("password")
+    @Operation(
+            summary = "비밀번호 번경",
+            description = "사용자 비밀번호를 변경합니다."
+    )
+    @ApiResponses(value = {
+            @ApiResponse(responseCode = "200", description = "닉네임 변경 성공"),
+            @ApiResponse(responseCode = "401", description = "잘못된 요청 파라미터")
+    })
+    public ResponseEntity<Void> patchPassword(
+            @RequestBody UserPatchPasswordRequest request,
+            HttpSession session
+    ) {
+
+        Long userId = getLoginUserId(session);
+        userService.patchPassword(userId, request);
+
+        return ResponseEntity.ok().build();
+    }
 
 
 }

--- a/src/main/java/com/gdg/linking/domain/user/UserService.java
+++ b/src/main/java/com/gdg/linking/domain/user/UserService.java
@@ -2,7 +2,10 @@ package com.gdg.linking.domain.user;
 
 import com.gdg.linking.domain.user.dto.request.UserCreateRequest;
 import com.gdg.linking.domain.user.dto.request.UserLoginRequest;
+import com.gdg.linking.domain.user.dto.request.UserPatchNickRequest;
+import com.gdg.linking.domain.user.dto.request.UserPatchPasswordRequest;
 import com.gdg.linking.domain.user.dto.response.UserCreateResponse;
+import com.gdg.linking.domain.user.dto.response.UserInfoResponse;
 import com.gdg.linking.domain.user.dto.response.UserLoginResponse;
 
 public interface UserService {
@@ -14,4 +17,11 @@ public interface UserService {
 
     Boolean findById(String id);
 
+    void patchNickName(Long userId, UserPatchNickRequest request);
+
+    void patchPassword(Long userId, UserPatchPasswordRequest request);
+
+    Boolean checkPassword(Long userId, String password);
+
+    UserInfoResponse getUserInfo(Long userId);
 }

--- a/src/main/java/com/gdg/linking/domain/user/UserServiceImpl.java
+++ b/src/main/java/com/gdg/linking/domain/user/UserServiceImpl.java
@@ -2,7 +2,10 @@ package com.gdg.linking.domain.user;
 
 import com.gdg.linking.domain.user.dto.request.UserCreateRequest;
 import com.gdg.linking.domain.user.dto.request.UserLoginRequest;
+import com.gdg.linking.domain.user.dto.request.UserPatchNickRequest;
+import com.gdg.linking.domain.user.dto.request.UserPatchPasswordRequest;
 import com.gdg.linking.domain.user.dto.response.UserCreateResponse;
+import com.gdg.linking.domain.user.dto.response.UserInfoResponse;
 import com.gdg.linking.domain.user.dto.response.UserLoginResponse;
 import com.gdg.linking.global.exception.custom.BadRequestException;
 import com.gdg.linking.global.exception.message.ErrorMessage;
@@ -76,5 +79,72 @@ public class UserServiceImpl implements UserService{
             return false;
         }
 
+    }
+
+    @Override
+    @Transactional
+    public void patchNickName(Long userId, UserPatchNickRequest request) {
+        User user = userRepository.findById(userId);
+
+        // 유저가 없는 경우 예외 처리 (선택 사항이나 권장됨)
+        if (user == null) {
+            throw new BadRequestException(ErrorMessage.MEMBER_NOTFOUND);
+        }
+
+        user.updateNickName(request.getNickName());
+    }
+
+    @Override
+    @Transactional
+    public void patchPassword(Long userId, UserPatchPasswordRequest request) {
+        User user = userRepository.findById(userId);
+
+        if (user == null) {
+            throw new BadRequestException(ErrorMessage.MEMBER_NOTFOUND);
+        }
+
+        // 2. 비밀번호 암호화
+        String encryptPassword = encryptSHA256(request.getPassword());
+
+        // 3. 비밀번호 변경 (Dirty Checking)
+        user.updatePassword(encryptPassword);
+    }
+
+    @Override
+    @Transactional
+    public UserInfoResponse getUserInfo(Long userId) {
+        // 1. 사용자 조회
+        User user = userRepository.findById(userId);
+
+        // 2. 예외 처리 (방어적 코드)
+        if (user == null) {
+            throw new BadRequestException(ErrorMessage.MEMBER_NOTFOUND);
+        }
+
+        // 3. Entity -> DTO 변환 후 반환
+        // (UserInfoResponse에 static factory method 'from'이 있다고 가정)
+        return UserInfoResponse.from(user);
+    }
+
+    @Override
+    @Transactional
+    public Boolean checkPassword(Long userId, String password) {
+        // 1. 사용자 조회
+        User user = userRepository.findById(userId);
+
+        if (user == null) {
+            throw new BadRequestException(ErrorMessage.MEMBER_NOTFOUND);
+        }
+
+        // 2. 입력받은 평문 비밀번호를 암호화 (가입/로그인 로직과 동일해야 함)
+        String encryptPassword = encryptSHA256(password);
+
+        // 3. DB에 저장된 암호화된 비밀번호와 비교
+        if (!user.getPassword().equals(encryptPassword)) {
+            // 비밀번호가 틀리면 false 반환 (Controller에서 401 등을 처리하거나 여기서 예외 발생)
+            return false;
+        }
+
+        return true;
     }
 }

--- a/src/main/java/com/gdg/linking/domain/user/dto/request/UserCheckPasswordRequest.java
+++ b/src/main/java/com/gdg/linking/domain/user/dto/request/UserCheckPasswordRequest.java
@@ -1,0 +1,14 @@
+package com.gdg.linking.domain.user.dto.request;
+
+import io.swagger.v3.oas.annotations.media.Schema;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+@Getter
+@NoArgsConstructor
+@Schema(description = "설정창 진입 전 비밀번호 확인 요청")
+public class UserCheckPasswordRequest {
+
+    @Schema(description = "확인할 비밀번호", example = "password1234")
+    private String password;
+}

--- a/src/main/java/com/gdg/linking/domain/user/dto/request/UserPatchNickRequest.java
+++ b/src/main/java/com/gdg/linking/domain/user/dto/request/UserPatchNickRequest.java
@@ -1,0 +1,17 @@
+package com.gdg.linking.domain.user.dto.request;
+
+import io.swagger.v3.oas.annotations.media.Schema;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+//무결성을 위한 기본 생성자
+@Getter
+@Schema(description = "닉네임 변경 요청")
+@NoArgsConstructor
+public class UserPatchNickRequest {
+
+    @Schema(description = "변경할 닉네임", example = "김생산")
+    private String nickName;
+
+}
+

--- a/src/main/java/com/gdg/linking/domain/user/dto/request/UserPatchPasswordRequest.java
+++ b/src/main/java/com/gdg/linking/domain/user/dto/request/UserPatchPasswordRequest.java
@@ -1,0 +1,16 @@
+package com.gdg.linking.domain.user.dto.request;
+
+import io.swagger.v3.oas.annotations.media.Schema;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+
+@Getter
+@Schema(description = "비밀번호 번경 요청")
+@NoArgsConstructor
+public class UserPatchPasswordRequest {
+
+    @Schema(description = "변경할 비밀번호", example = "newpassword123!")
+    private String password;
+
+}

--- a/src/main/java/com/gdg/linking/domain/user/dto/response/UserInfoResponse.java
+++ b/src/main/java/com/gdg/linking/domain/user/dto/response/UserInfoResponse.java
@@ -1,0 +1,21 @@
+package com.gdg.linking.domain.user.dto.response;
+
+import com.gdg.linking.domain.user.User;
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+
+@Getter
+@AllArgsConstructor
+public class UserInfoResponse {
+    private String loginId;
+    private String nickName;
+
+
+    // User 엔티티를 DTO로 변환하는 생성자
+    public static UserInfoResponse from(User user) {
+        return new UserInfoResponse(
+                user.getLoginId(),
+                user.getNickName()
+        );
+    }
+}

--- a/src/main/java/com/gdg/linking/global/exception/message/ErrorMessage.java
+++ b/src/main/java/com/gdg/linking/global/exception/message/ErrorMessage.java
@@ -3,6 +3,6 @@ package com.gdg.linking.global.exception.message;
 public class ErrorMessage {
 
     public static final String MEMBER_ALREADY_EXISTS = "이미 존재하는 로그인 아이디 입니다";
-    public static final String MEMBER_NOTFOUND = "아이디나 비밀번호가 틀렸습니다";
+    public static final String MEMBER_NOTFOUND = "존재하지 않는 사용자 입니다";
 
 }


### PR DESCRIPTION

## PR 제목

### PR을 한 이유 🎯

- 항목별 아이템들을 따로 검색하는 기능을 추가로 만들었음

### 이슈 번호 📎

- #51 

### 변경사항 🛠

- 닉네임 및 비밀번호 변경 서비스 로직 구현 (Dirty Checking 적용)
- 마이페이지 진입 시 비밀번호 확인(checkPassword) 및 내 정보 조회(getUserInfo) 기능 구현

- 카테고리(마감임박, 중요, 청소, 휴지통) 내 키워드 검색을 위한 JPQL 쿼리 추가 (ItemRepository)
- 필터와 검색어를 조합하여 처리하도록 Service/Controller 로직 통합 및 개선
- 필터가 없는 경우(null)에도 전체 검색이 동작하도록 예외 처리 추가


### 특이사항 📌

- 프론트에서 비밀번호 변경 요청 순서가 바뀔 수 있음
