### PR TITLE
fix: 계층형 폴더 대량 삭제 및 복구 로직 개선 (재귀적 상태 전파 적용)

### DIFF
--- a/src/main/java/com/gdg/linking/domain/folder/FolderServiceImpl.java
+++ b/src/main/java/com/gdg/linking/domain/folder/FolderServiceImpl.java
@@ -123,6 +123,8 @@ public class FolderServiceImpl implements FolderService {
         Folder folder = folderRepository.findById(folderId)
                 .orElseThrow(() -> new RuntimeException("삭제할 폴더가 존재하지 않습니다."));
 
+        folder.updateStatus(Item.ItemStatus.TRASH);
+
         // 재귀적으로 상태 변경 실행
         softDeleteRecursive(folder);
     }
@@ -134,11 +136,11 @@ public class FolderServiceImpl implements FolderService {
             item.updateStatus(Item.ItemStatus.ORPHAN); // Item 엔티티의 기존 메서드 활용
         }
 
-        // 현재 폴더 자체를 휴지통으로
-        folder.updateStatus(Item.ItemStatus.TRASH);
 
         // 모든 하위 폴더들에 대해서도 동일한 작업 수행 (재귀 호출)
         for (Folder child : folder.getChildFolders()) {
+            // 현재 폴더 자체를 휴지통으로
+            child.updateStatus(Item.ItemStatus.ORPHAN);
             softDeleteRecursive(child);
         }
     }
@@ -282,6 +284,7 @@ public class FolderServiceImpl implements FolderService {
 
             // 3. 폴더 상태를 TRASH로 변경 (Recursive)
             // Folder 엔티티의 updateStatus가 하위 아이템들의 상태도 변경하도록 설계되어 있다면 편리합니다.
+            folder.updateStatus(Item.ItemStatus.TRASH);
             softDeleteRecursive(folder);
 
             // 4. 폴더 내 아이템들의 예약 알림 삭제 (필요 시)
@@ -353,7 +356,7 @@ public class FolderServiceImpl implements FolderService {
 
         // 2. 내부 아이템들 복구
         for (Item item : folder.getItems()) {
-            if (item.getStatus() == Item.ItemStatus.TRASH) {
+            if (item.getStatus() == Item.ItemStatus.ORPHAN) {
                 item.restore();
                 // 마감 알림 등 부가 로직 필요 시 추가 (notificationService 등)
                 if (item.getDeadline() != null) {
@@ -364,7 +367,7 @@ public class FolderServiceImpl implements FolderService {
 
         // 3. 하위 폴더들 복구 (재귀 호출)
         for (Folder child : folder.getChildFolders()) {
-            if (child.getStatus() == Item.ItemStatus.TRASH) {
+            if (child.getStatus() == Item.ItemStatus.ORPHAN) {
                 restoreRecursive(child);
             }
         }

--- a/src/main/java/com/gdg/linking/domain/folder/FolderServiceImpl.java
+++ b/src/main/java/com/gdg/linking/domain/folder/FolderServiceImpl.java
@@ -131,7 +131,7 @@ public class FolderServiceImpl implements FolderService {
     private void softDeleteRecursive(Folder folder) {
         // 현재 폴더에 포함된 모든 아이템들을 휴지통으로 이동
         for (Item item : folder.getItems()) {
-            item.updateStatus(Item.ItemStatus.TRASH); // Item 엔티티의 기존 메서드 활용
+            item.updateStatus(Item.ItemStatus.ORPHAN); // Item 엔티티의 기존 메서드 활용
         }
 
         // 현재 폴더 자체를 휴지통으로
@@ -282,7 +282,7 @@ public class FolderServiceImpl implements FolderService {
 
             // 3. 폴더 상태를 TRASH로 변경 (Recursive)
             // Folder 엔티티의 updateStatus가 하위 아이템들의 상태도 변경하도록 설계되어 있다면 편리합니다.
-            folder.updateStatus(Item.ItemStatus.TRASH);
+            softDeleteRecursive(folder);
 
             // 4. 폴더 내 아이템들의 예약 알림 삭제 (필요 시)
             for (Item item : folder.getItems()) {

--- a/src/main/java/com/gdg/linking/domain/item/Item.java
+++ b/src/main/java/com/gdg/linking/domain/item/Item.java
@@ -25,7 +25,7 @@ import java.util.List;
 public class Item {
 
     public enum ItemStatus {
-        ACTIVE, COMPLETED, TRASH
+        ACTIVE, COMPLETED, TRASH,ORPHAN
     }
 
     @Id

--- a/src/main/java/com/gdg/linking/domain/item/Item.java
+++ b/src/main/java/com/gdg/linking/domain/item/Item.java
@@ -59,6 +59,7 @@ public class Item {
     @Column(name = "memo")
     private String memo;
 
+    @Builder.Default
     @Column(name = "importance")
     private boolean importance = false;
 
@@ -67,6 +68,7 @@ public class Item {
 
     @Enumerated(EnumType.STRING)
     @Column(name = "status")
+    @Builder.Default
     private ItemStatus status = ItemStatus.ACTIVE;
 
     @Column(name = "deleted_at")
@@ -87,6 +89,7 @@ public class Item {
     }
 
     @ManyToMany
+    @Builder.Default
     @JoinTable(
             name = "item_relations",           // 생성될 중간 테이블 이름
             joinColumns = @JoinColumn(name = "from_id"),    // 현재 아이템(출발점) 외래키

--- a/src/main/java/com/gdg/linking/domain/tag/Tag.java
+++ b/src/main/java/com/gdg/linking/domain/tag/Tag.java
@@ -23,6 +23,7 @@ public class Tag {
     private String tagName;
 
     @OneToMany(mappedBy = "tag")
+    @Builder.Default
     private List<ItemTag> postTags = new ArrayList<>();
 
 

--- a/src/main/java/com/gdg/linking/domain/user/User.java
+++ b/src/main/java/com/gdg/linking/domain/user/User.java
@@ -36,11 +36,11 @@ public class User {
     // 프로필
     @Column(name = "total_xp")
     @Builder.Default
-    private int totalXp = 0;
+    private Integer totalXp = 0;
 
     @Column(name = "level")
     @Builder.Default
-    private int level = 1;
+    private Integer level = 1;
 
     @Column(name = "profile_image")
     @Builder.Default


### PR DESCRIPTION
### PR을 한 이유 🎯

- 부모 폴더를 삭제해도 하위 요소가 ACTIVE 상태로 남아 검색 결과에 노출되는 버그를 방지하고, 복구 시 계층 구조가 꼬이지 않도록 Windows 탐색기와 유사한 방식으로 상태 전파 로직을 전면 수정했습니다.


### 변경사항 🛠
- 폴더 삭제 (deleteFolder, deleteFolders)

  - 삭제 대상(부모) 폴더의 상태는 TRASH로 변경합니다.

  - 하위 폴더 및 아이템은 재귀적으로 탐색하여, 기존에 살아있던(ACTIVE) 요소들만 ORPHAN(고아) 상태로 일괄 변경합니다.

- 폴더 복구 (restoreFolder, restoreFolders)

  - 복구 대상 폴더의 상태를 TRASH에서 ACTIVE로 변경합니다.

  - 하위 계층을 재귀적으로 탐색하여, 부모가 삭제될 때 함께 고아가 되었던(ORPHAN) 요소들만 찾아 다시 ACTIVE로 복원합니다.

